### PR TITLE
Get rid of BitBoard’s dependency on `QtWidgets`

### DIFF
--- a/src/database/bitboard.h
+++ b/src/database/bitboard.h
@@ -121,6 +121,36 @@ public:
     QString toFen(bool forceExtendedFEN=false) const;
     /** Return a FEN string in human readable format based on current board position */
     QString toHumanFen() const;
+
+    // Move formatting
+    /** Maps piece type to short string used in SAN */
+    class PieceNames
+    {
+    public:
+        PieceNames();
+        PieceNames(const QString& k, const QString& q, const QString& r, const QString& b, const QString& n);
+
+        /** @returns abbreviation for piece @p type */
+        QString get(PieceType type) const;
+        /** Set abbreviation for a piece @p type */
+        void set(PieceType type, const QString& name);
+        /** Set abbreviations for all piece types at once
+         *  @note This method expects 1 letter per piece.
+         * If called with a string of incompatible length, FAN will be used.
+         */
+        void set(const QString& pieces);
+
+        /** unicode letters (♔♕♖♗♘) aka FAN */
+        static const PieceNames& figurine();
+        /** english convention (KQRBN) */
+        static const PieceNames& english();
+        /** global customizable instance */
+        static PieceNames& custom();
+    private:
+        static const int PieceTypeCount = 7;
+        QString m_names[PieceTypeCount];
+    };
+
     /** Return a SAN string representation of given move */
     QString moveToSan(const Move& move, bool translate = false, bool extend = false) const;
     /** @return a SAN string representing a given move with move number. */
@@ -508,6 +538,18 @@ inline Square BitBoard::enPassantSquare() const
 inline CastlingRights BitBoard::castlingRights() const
 {
     return m_castle;
+}
+
+inline QString BitBoard::PieceNames::get(PieceType type) const
+{
+    Q_ASSERT(0 <= type && type < PieceTypeCount);
+    return m_names[type];
+}
+
+inline void BitBoard::PieceNames::set(PieceType type, const QString &name)
+{
+    Q_ASSERT(0 <= type && type < PieceTypeCount);
+    m_names[type] = name;
 }
 
 #endif // BITBOARD_H_INCLUDED

--- a/src/database/settings.cpp
+++ b/src/database/settings.cpp
@@ -7,6 +7,7 @@
  *   (at your option) any later version.                                   *
  ***************************************************************************/
 
+#include "bitboard.h"
 #include "boardtheme.h"
 #include "settings.h"
 
@@ -26,13 +27,24 @@
 #endif // _MSC_VER
 
 Settings::Settings() : QSettings(IniFormat, UserScope, "chessx", "chessx")
-{}
+{
+    initialize();
+}
 
 Settings::Settings(const QString &fileName) : QSettings(fileName, IniFormat)
-{}
+{
+    initialize();
+}
 
 Settings::~Settings()
 {}
+
+void Settings::initialize()
+{
+    beginGroup("GameText");
+    BitBoard::PieceNames::custom().set(getValue("PieceString").toString());
+    endGroup();
+}
 
 bool Settings::layout(QWidget* w)
 {
@@ -497,6 +509,15 @@ QVariant Settings::getValue(const QString &key) const
         }
     }
     return value(key);
+}
+
+void Settings::setValue(const QString &key, const QVariant& val)
+{
+    QSettings::setValue(key, val);
+    if (key == "PieceString" && group() == "GameText")
+    {
+        BitBoard::PieceNames::custom().set(val.toString());
+    }
 }
 
 QString Settings::getThemePath(QString effect, QString pieces) const

--- a/src/database/settings.h
+++ b/src/database/settings.h
@@ -81,6 +81,8 @@ public:
 
     /// Overloading value from QSettings with a single place where defaults come from
     QVariant getValue(const QString &key) const;
+    /// Shadow `QSettings::setValue()` to have a hook for updating global state
+    void setValue(const QString& key, const QVariant& val);
 
     void setMap(const QString& key, const OptionValueList& map);
     void getMap(const QString& key, OptionValueList& map);
@@ -106,6 +108,7 @@ public:
     static QString portableIniPath();
 private:
 
+    void initialize();
     QMap<QString, QVariant> initDefaultValues() const;
     QString m_dataPath;
 


### PR DESCRIPTION
I've been trying to split the monolithic codebase into separate "modules" (static libraries) and discovered this implicit dependency that goes "wrong way" (from low-level to UI classes)