### PR TITLE
Fix editing comments with special annotations

### DIFF
--- a/src/database/gamex.cpp
+++ b/src/database/gamex.cpp
@@ -1629,8 +1629,6 @@ bool GameX::setAnnotation(QString annotation, MoveId moveId, Position position)
 bool GameX::editAnnotation(QString annotation, MoveId moveId, Position position)
 {
     GameX state = *this;
-    QString spec = specAnnotations(moveId);
-    annotation.append(spec);
     if (dbSetAnnotation(annotation, moveId, position))
     {
         dbIndicateAnnotationsOnBoard();


### PR DESCRIPTION
In the editComment widget under the board, typing "a" to a comment containing special annotations, eg "[%csl Gf4]", causes the comment to change to "[%csl Gf4]a[%csl Gf4]" (the special comment appears twice). This is caused by GameX::editAnnotationEditing which appends the special annotations to the text, which already contains them! (I guess the code came from the edit comment dialog in which the text does not contain the special annotations).

Removing the 2 lines of appending code fixes the issue, now both the comment and the special annotations are editable.