### PR TITLE
bugfix: update annotation arrows after non-main mouse move

### DIFF
--- a/src/database/gamex.cpp
+++ b/src/database/gamex.cpp
@@ -2154,6 +2154,16 @@ void GameX::moveToLineEnd()
     }
 }
 
+bool GameX::dbMoveToId(MoveId moveId, QString* algebraicMoveList)
+{
+    bool moved = m_moves.moveToId(moveId, algebraicMoveList);
+    if (moved)
+    {
+        indicateAnnotationsOnBoard();
+    }
+    return moved;
+}
+
 int GameX::forward(int count)
 {
     int moved = m_moves.forward(count);

--- a/src/database/gamex.h
+++ b/src/database/gamex.h
@@ -405,7 +405,7 @@ public :
     bool isEmpty() const;
 
     // ***** Moving through game *****
-    bool dbMoveToId(MoveId moveId, QString* algebraicMoveList=nullptr) { return m_moves.moveToId(moveId, algebraicMoveList); }
+    bool dbMoveToId(MoveId moveId, QString* algebraicMoveList=nullptr);
     int forward(int count = 1);
     int backward(int count = 1);
     void moveToStart();


### PR DESCRIPTION
The following PGN demontrates the bug:
```
1. e4 { [%cal Gg1f3]}  ( 1. d4 { [%cal Gc2c4]} ) *
```

Both moves contain arrows.
- After selecting e4 (main move) in __any way__ (mouse, notation list, keyboard), the arrow is shown
- After selecting d4 with the __mouse__, the arrow is __not__ shown (it is shown if d4 is selected from the variations list).

The problem is that `GameX::forward` calls `indicateAnnotationsOnBoard()`, but `GameX::dbMoveToId` does not. This PR fixes this.




