### PR TITLE
bugfix: update annotation arrows after non-main mouse move (alternative fix)

### DIFF
--- a/src/database/gamex.cpp
+++ b/src/database/gamex.cpp
@@ -1237,7 +1237,7 @@ bool GameX::findNextMove(Square from, Square to, PieceType promotionPiece)
                 if(m.from() == from && m.to() == to &&
                         ((promotionPiece == None) || ((m.isPromotion() && (pieceType(m.promotedPiece()) == promotionPiece)))))
                 {
-                    dbMoveToId(*i);
+                    enterVariation(*i);
                     return true;
                 }
             }


### PR DESCRIPTION
Maybe this is the proper (and simpler) way to fix #45.