### PR TITLE
Metadata file for ChessX and support for 'qmake install'

### DIFF
--- a/chessx.pro
+++ b/chessx.pro
@@ -52,6 +52,33 @@ macx {
   QMAKE_CXXFLAGS_DEBUG *= -m64 -O0 --coverage
 }
 
+
+unix|!macx {
+    isEmpty(PREFIX) {
+        bsd {
+            PREFIX = /usr/local
+        }
+        PREFIX = /usr
+    }
+    BINDIR = $$PREFIX/bin
+    DATADIR = $$PREFIX/share
+
+    INSTALLS += appdata desktop icons binfiles
+
+    appdata.files = unix/io.sourceforge.ChessX.metainfo.xml
+    appdata.path = $$DATADIR/metainfo
+    desktop.files = unix/chessx.desktop
+    desktop.path = $$DATADIR/applications
+
+    icons.path = $$DATADIR/icons/hicolor
+    icons.commands = install -Dm644 data/images/chessx.png    $${icons.path}/128x128/apps/chessx.png; \
+                     install -Dm644 data/images/chessx-32.png $${icons.path}/32x32/apps/chessx.png; \
+                     install -Dm644 data/images/chessx-64.png $${icons.path}/64x64/apps/chessx.png;
+
+    binfiles.files = release/chessx
+    binfiles.path = $$BINDIR
+}
+
 scid {
   # Scid sources
   HEADERS += \

--- a/unix/io.sourceforge.ChessX.metainfo.xml
+++ b/unix/io.sourceforge.ChessX.metainfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>io.sourceforge.ChessX.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <name>ChessX</name>
+  <summary>Free Chess Database</summary>
+  <description>
+    <p>
+			ChessX is an Open Source chess database. With ChessX you can operate on your collection of chess games in many ways:
+browse, edit, add, organize, analyze, etc.
+		</p>
+    <ul>
+      <li>Load and save PGN files</li>
+      <li>Work with multiple databases simultaneously</li>
+      <li>Browse games, including variations</li>
+      <li>Enter moves, variations, comments</li>
+      <li>Setup board, copy/paste FEN, merge games</li>
+      <li>Search in Databases for text or positions</li>
+      <li>Display tree of moves for the current position</li>
+      <li>Analyze using UCI and Winboard/Xboard Chess engines</li>
+      <li>Prepare for openings or opponents</li>
+      <li>Training mode (next move is hidden)</li>
+      <li>FICS Support</li>
+    </ul>
+  </description>
+  <releases>
+    <release version="1.5.6" date="2021-02-27"/>
+    <release version="1.5.4" date="2020-05-12"/>
+    <release version="1.5.0" date="2019-05-05"/>
+    <release version="1.4.6" date="2017-04-14"/>
+  </releases>
+  <screenshots>
+    <screenshot type="default">
+      <image>http://i1-win.softpedia-static.com/screenshots/ChessX_1.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://chessx.sourceforge.io</url>
+  <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
- adds appstream metadata file for ChessX
- adds (q)make install support for linux and bsd

Desirable but not necessary changes:
- Better screenshots for ChessX. The only ones at https://chessx.sourceforge.io/ are too small and pixelated to be used. Newer and larger screenshots could then be used in the appstream file instead of the present one (http://i1-win.softpedia-static.com/screenshots/ChessX_1.png).