### PR TITLE
Help information updates

### DIFF
--- a/data/help/about0.html
+++ b/data/help/about0.html
@@ -50,7 +50,10 @@ browse, edit, add, organize, analyze, etc.</p>
 <li class="bullet">Search header (click on columns in GameList header)<br />
 <li class="bullet">Display opening tree for current position<br />
 <li class="bullet">Analyze using UCI and Winboard/Xboard Chess engines<br />
-<li class="bullet">Play Online on Free Internet Chess Server (FICS)
+<li class="bullet">Play Online on <a href="https://www.freechess.org/">Free
+  Internet Chess Server
+  (FICS)</a>, <a href="https://lichess.org/">Lichess.org</a>
+  and <a href="https://www.chess.com/">Chess.com</a> 
 </ul>
 <h3><a name="Plans"></a>Planned Features</h3>
 <ul>
@@ -62,8 +65,15 @@ browse, edit, add, organize, analyze, etc.</p>
 
 <h3><a name="Development"></a>Development</h3>
 
-<p>The code uses the Qt library. To develop, you need Qt 4.8.1 or later. SVN is used to manage development and SourceForge Tracker to keep track of bug reports and feature requests. All classes are documented using <a href="http://www.stack.nl/~dimitri/doxygen/">Doxygen</a>. </p>
-<p>For a long time, ChessX was pushed forward by <strong>Michal Rudolf</strong>.</p>
+<p>The code uses the <a href="https://doc.qt.io/qt-5/">Qt library</a>. To compile from source, <em>Qt 5.14.1</em> or
+  later is
+  required. <a href="https://github.com/Isarhamster/chessx">Github</a> is   
+  used to   manage development. SourceForge Tracker is used to keep track of 
+  bug reports   and feature requests. <!--Consider using ''Isues'' in github
+  to bring all   development to the same location?--> All classes are documented
+  using <a href="https://www.doxygen.nl/index.html">Doxygen</a>. </p>
+
+<p>For a long time, ChessX development was pushed forward by <strong>Michal Rudolf</strong>.</p>
 <p>Currently, there are two active ChessX developers: <strong>James Coons</strong> and current maintainer <strong>Jens Nissen</strong>. The main tester and usability expert is <strong>Bruno Rizzuti</strong>.</p>
 <p>Among inactive developers we would like to mention <strong>Marius Roets</strong>, <strong>Sean Estabrooks</strong>, <strong>Rico Zenklusen</strong>, <strong>William Hoggarth</strong> and <strong>Ejner Borgbjerg</strong> who wrote significant parts of code. <strong>Heinz Hopfgartner</strong> made useful tests and maintained Mac port.</p>
 <p>If you wish to participate in the project (either as a developer or a tester), please sign up to the <a href="http://lists.sourceforge.net/lists/listinfo/chessx-developer">developer mailing list</a> and introduce yourself.</p>


### PR DESCRIPTION
* Indicate that in addition to FICS, now functionality to Lichess.org
and Chess.com is being implemented
* Specify that > Qt 5.14.1 is required to compile
* Specify that development repository has been relocated to github
* Update Doxygen linking