### PR TITLE
Fics whitepieces bugfix

### DIFF
--- a/src/database/settings.cpp
+++ b/src/database/settings.cpp
@@ -256,7 +256,7 @@ QMap<QString, QVariant> Settings::initDefaultValues() const
     map.insert("/MainWindow/GameToolBar", false);
     map.insert("/MainWindow/VerticalTabs", false);
     map.insert("/MainWindow/DarkTheme", false);
-    map.insert("/MainWindow/Theme", "plastique");
+    map.insert("/MainWindow/Theme", "Adwaita");
     map.insert("/MainWindow/StayOnTop", false);
     map.insert("/MainWindow/FilterFollowsGame", false);
     map.insert("/MainWindow/ShowMenuIcons", true);

--- a/src/dialogs/preferences.cpp
+++ b/src/dialogs/preferences.cpp
@@ -576,6 +576,7 @@ void PreferencesDialog::restoreSettings()
         ui.theme->addItem(s);
     }
     ui.theme->addItem("Orange");
+    ui.theme->addItem("Plastik");
     int n = ui.theme->findText(AppSettings->getValue("/MainWindow/Theme").toString());
     if (n>=0) ui.theme->setCurrentIndex(n);
 


### PR DESCRIPTION
### This pull request fixes Reported bug [#301](https://sourceforge.net/p/chessx/bugs/301/)
https://sourceforge.net/p/chessx/bugs/301/


The bug reported on 301 was persistent for me. 
I narrowed it down to a Default Setting in the theme, which was being selected as Adwaita-Dark

This happened every time I first open the preferences menu. 

The generated .config/chessx/chessx.ini file would list "Adwaita-Dark" and from there on, FICS would not be able to play the white pieces, regardless of whether match was generated with "match" or "seek" command
At that point changing themes was not useful. The bug persisted, and only deletion of the chessx.ini file would clear that issue.


The default map was trying to set "plastique" and failing. 

I changed it to default to "Adawita" and added "Plastik" (not plastique) to the combo-box. 

This worked for me in, and now I can use fics correctly.

Regards,

