### PR TITLE
Silencing Compilation Warnings

### DIFF
--- a/src/database/tablebase.cpp
+++ b/src/database/tablebase.cpp
@@ -133,7 +133,7 @@ void OnlineTablebase::httpDone(QNetworkReply *reply)
                     QJsonValue jdtm = doc.object().value("dtm");
                     int dtm = jdtm.toInt();
                     QJsonValue jdtz = doc.object().value("dtz");
-                    int bestScore;
+                    int bestScore =0; //Initialize as zero to avoid compilation warning
                     if (result)
                     {
                         bestScore = jdtm.isNull() ? 0 : dtm - ((dtm>0) ? 1:(-1));
@@ -199,7 +199,7 @@ void OnlineTablebase::httpDone(QNetworkReply *reply)
                 {
                     QList<Move> bestMoves;
                     bool first = true;
-                    int bestScore;
+                    int bestScore =0; //Initialize as zero to avoid compilation warning
                     foreach(QString tbMove, moveList)
                     {
                         QStringList fld = tbMove.split(' ',Qt::SkipEmptyParts);

--- a/src/gui/databaselistmodel.cpp
+++ b/src/gui/databaselistmodel.cpp
@@ -115,6 +115,9 @@ QVariant DatabaseListModel::data(const QModelIndex &index, int role) const
             case 3: return QPixmap(":/images/folder_favorite3.png");
             case 4: return QPixmap(":/images/startup.png");
             case 5: return QPixmap(":/images/active.png");
+	    default: return QPixmap( );
+	      //silences compilation warning ensuring
+	      //an empty pixmap is returned if no case is a match 
             }
         }
         case DBLV_OPEN:

--- a/src/gui/htmlitemdelegate.cpp
+++ b/src/gui/htmlitemdelegate.cpp
@@ -10,7 +10,7 @@ HTMLItemDelegate::HTMLItemDelegate(QObject *parent) :
 
 void HTMLItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    QStyleOptionViewItemV4 options = option;
+  QStyleOptionViewItem options = option; // silences deprecated QstyleOptionViewItem warning
     initStyleOption(&options, index);
 
     painter->save();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2419,6 +2419,7 @@ bool MainWindow::announceMove(Move m)
         }
     }
 #endif
+    (void) m; //silences unused parameter `m' ifndef USE_SPEECH
     return false;
 }
 


### PR DESCRIPTION
### Current compilation warnings addressed,

When compiling with:

- Qmake version 3.1
- GNU/Linux 5.3.18-lp152.87-default 
- gcc (SUSE Linux) 7.5.0
- Qt version 5.12.7 in /usr/lib64
	- source code patched for compiling in Lower that Qt 5.14.1