### PR TITLE
Fix broken DB download URLs

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2303,11 +2303,11 @@ void MainWindow::QueryLoadDatabase()
     {
         if(dlg.largeDB())
         {
-            openDatabaseUrl("http://chessx.sourceforge.net/db/bundesliga2000.pgn.zip", false);
+            openDatabaseUrl("http://chessx.sourceforge.io/db/bundesliga2000.pgn.zip", false);
         }
         else
         {
-            openDatabaseUrl("http://chessx.sourceforge.net/db/SBL1213.pgn.zip", false);
+            openDatabaseUrl("http://chessx.sourceforge.io/db/SBL1213.pgn.zip", false);
         }
     }
     AppSettings->setValue("/General/BuiltinDbInstalled", QVariant(true));


### PR DESCRIPTION
The current version (1.5.6) of ChessX raises the following errors:

      Database bundesliga2000.pgn.zip cannot be accessed at the moment ().
      Database SBL1213.pgn.zip cannot be accessed at the moment ().

It appears that the URLs of the source files have changed from *.net to *.io.