### PR TITLE
Make output of XTELL more verbose

### DIFF
--- a/src/gui/ficsconsole.cpp
+++ b/src/gui/ficsconsole.cpp
@@ -761,6 +761,10 @@ void FicsConsole::HandleMessage(int blockCmd,QString s)
                 {
                     m_ficsClient->sendCommand("xtell relay next");
                 }
+		else
+		{
+		    ui->textIn->appendPlainText(s);
+		}
             }
             break;
         case FicsClient::BLKCMD_WHO:


### PR DESCRIPTION
Allows most XTELLs to be printed in the messages window

Per example, when using fics to send a command, like

`td help schedule`

The response is a CMDBLK 150, XTELL. The answer currently is muted and the information requested is not printed. 
By making XTELL print verbosely as a default, then these commands become functional, and the requested information is displayed in the ui

 