### PR TITLE
Fix cmake build/compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(eco STATIC
   database/ecopositions.h
   guess/guess_compileeco.cpp
   guess/guess_compileeco.h
+  gui/qt6compat.h
 )
 
 target_link_libraries(eco
@@ -77,6 +78,7 @@ target_link_libraries(eco
     qt_config
   PUBLIC
     board
+    gui
     Qt5::Core
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -294,6 +294,9 @@ add_library(gui STATIC
   dialogs/matchparameterdlg.cpp
   dialogs/matchparameterdlg.h
   dialogs/matchparameterdlg.ui
+  dialogs/onlinebase.cpp
+  dialogs/onlinebase.h
+  dialogs/onlinebase.ui
   dialogs/preferences.cpp
   dialogs/preferences.h
   dialogs/preferences.ui
@@ -340,6 +343,8 @@ add_library(gui STATIC
   gui/chartwidget.h
   gui/chessbrowser.cpp
   gui/chessbrowser.h
+  gui/chessxsettings.cpp
+  gui/chessxsettings.h
   gui/colorlist.cpp
   gui/colorlist.h
   gui/databaselist.cpp
@@ -434,6 +439,8 @@ add_library(gui STATIC
   gui/tableview.cpp
   gui/tableview.h
   gui/tagdetailwidget.ui
+  gui/testadapter.cpp
+  gui/testadapter.h
   gui/textbrowserex.h
   gui/textedit.cpp
   gui/textedit.h


### PR DESCRIPTION
Currently qmake is the officially supported build system but I see cmake is available, but not kept up to date. I found one commit/branch from @lgbaldoni and added qt6compat.h.

It builds for both release and debug targets on Kubuntu 22.04.

The open question I have if it makes sense to have gui in the target_link_libraries for "eco", it feels a bit out of scope with such dependency.