### PR TITLE
Fix compilation on speechless systems.

### DIFF
--- a/src/gui/chessxsettings.cpp
+++ b/src/gui/chessxsettings.cpp
@@ -19,7 +19,9 @@
 #include <QWidget>
 #include <QMainWindow>
 #include <QSplitter>
+#ifdef USE_SPEECH
 #include <QTextToSpeech>
+#endif
 #include <QLayout>
 
 using namespace chessx;

--- a/src/gui/chessxsettings.h
+++ b/src/gui/chessxsettings.h
@@ -18,10 +18,8 @@ public:
     virtual void setLayout(const QWidget* w);
 
     static QLocale locale(); // Get the locale based upon current settings
-#ifdef USE_SPEECH
     static QStringList availableVoices(QString lang); // Get the list of voices based upon selected locale
     static void configureSpeech(QTextToSpeech* speech);
-#endif
 
 protected:
     virtual void initWidgetValues(QMap<QString, QVariant>& map) const;


### PR DESCRIPTION
This patch fixes two following problems:
- QTextToSpeech is included even if it is not needed. When it is not available, the compilation is broken.
- When USE_SPEECH is not defined, header files excludes availableVoices and configureSpeech  methods from ChessXSettings class, though they are still defined in chessxsettings.cpp (albeit as empty ones) and used elsewhere. This breaks the compilation.