### PR TITLE
Fixed: ECO Classification is a move behind

### DIFF
--- a/src/database/gamex.cpp
+++ b/src/database/gamex.cpp
@@ -1719,15 +1719,20 @@ QString GameX::ecoClassify() const
     }
     g.m_moves.moveToEnd();
 
-    //search backwards for the first eco position
-    while(g.m_moves.backward())
+    // Because we now only move backward() after the loop, we must ensure there are some moves
+    if (g.m_moves.countMoves() == 0) {
+        return QString();
+    }
+
+    // Search backwards for the first eco position
+    do
     {
         QString eco;
         if (EcoPositions::isEcoPosition(g.board(),eco))
         {
             return eco;
         }
-    }
+    } while(g.m_moves.backward());
 
     return QString();
 }


### PR DESCRIPTION
Fixes issue where ECO classification is a move behind.

This happens because before ECO is checked the first time, the game is already moved backwards.

![image](https://github.com/Isarhamster/chessx/assets/10122432/083ad1e8-c745-491d-8f83-69d646bdd1e2)

Note: In the unpatched version, if you play ANY additional move, then the ECO is properly recognized as the Nescafe frappe attack