### PR TITLE
Fix compilation on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,15 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 
 project(chessx LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-option(ENABLE_SOUNDS "Enable sounds (requires Qt5::Multimedia)" ON)
-option(ENABLE_TTS "Enable text-to-speech (requires Qt5::TextToSpeech)" ON)
+option(ENABLE_SOUNDS "Enable sounds (requires Qt6::Multimedia)" ON)
+option(ENABLE_TTS "Enable text-to-speech (requires Qt6::TextToSpeech)" ON)
 option(ENABLE_SCID_SUPPORT "Enable support for Scid database format (*.si4)" ON)
 
 add_subdirectory(dep)
-
 # common definitions to use with Qt
 add_library(qt_config INTERFACE)
 target_compile_definitions(qt_config INTERFACE
@@ -23,7 +22,7 @@ target_compile_definitions(qt_config INTERFACE
 )
 
 set(REQUIRED_QT_COMPONENTS
-  Core Xml DBus Network OpenGL Svg PrintSupport Gui Widgets
+  Core Xml DBus Network OpenGL Svg PrintSupport Gui Widgets Core5Compat
 )
 
 if (ENABLE_SOUNDS)
@@ -34,7 +33,7 @@ if (ENABLE_TTS)
   list(APPEND REQUIRED_QT_COMPONENTS TextToSpeech)
 endif()
 
-find_package(Qt5 REQUIRED
+find_package(Qt6 REQUIRED
   LinguistTools
   "${REQUIRED_QT_COMPONENTS}"
   Test
@@ -61,7 +60,7 @@ set_source_files_properties(${TRANSLATIONS_SRC_FILES}
   OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/i18n"
 )
 
-qt5_add_translation(TRANSLATIONS_BIN_FILES ${TRANSLATIONS_SRC_FILES})
+qt6_add_translation(TRANSLATIONS_BIN_FILES ${TRANSLATIONS_SRC_FILES})
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -110,6 +109,7 @@ target_link_libraries(chessx PRIVATE
   board
   eco
   gui
+  Qt6::Multimedia
 )
 
 if (CMAKE_HOST_APPLE)
@@ -148,4 +148,31 @@ if (ENABLE_TESTING)
   enable_testing()
   add_subdirectory(tests/unittests)
 endif()
+
+if (ENABLE_SOUNDS)
+  target_compile_definitions(chessx
+    PRIVATE
+      USE_SOUND
+  )
+  target_link_libraries(chessx PRIVATE Qt6::Multimedia)
+  if (UNIX AND NOT APPLE)
+    # on Linux QtMultimedia links to pulseaudio
+    find_package(PulseAudio REQUIRED) 
+    target_link_libraries(chessx
+      PRIVATE
+        ${PULSEAUDIO_LIBRARY}
+        ${PULSEAUDIO_MAINLOOP_LIBRARY}
+    )
+  endif()
+endif()
+
+if (ENABLE_TTS)
+  target_compile_definitions(chessx
+    PRIVATE
+      USE_SPEECH
+  )
+  target_link_libraries(chessx PRIVATE Qt6::TextToSpeech)
+endif()
+
+
 

--- a/chessx.pro
+++ b/chessx.pro
@@ -531,9 +531,8 @@ INCLUDEPATH += src/quazip
 INCLUDEPATH += $$[QT_INSTALL_PREFIX]/src/3rdparty/zlib
 
 win32 {
-  # DEFINES += ZLIB_WINAPI
-  # LIBS += -lz
-  INCLUDEPATH += $$[QT_INSTALL_HEADERS]/QtZlib
+  DEFINES += ZLIB_WINAPI
+  LIBS += -lz
   win32-g++:LIBS += -lz
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(bitboard
   PRIVATE
     qt_config
   PUBLIC
-    Qt5::Core
+    Qt6::Core
 )
 
 if (cxx_std_11 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
@@ -79,7 +79,7 @@ target_link_libraries(eco
   PUBLIC
     board
     gui
-    Qt5::Core
+    Qt6::Core
 )
 
 add_library(database-core STATIC
@@ -235,17 +235,20 @@ target_include_directories(database
     database
   PRIVATE
     gui
+
 )
 
 target_link_libraries(database
   PRIVATE
     qt_config
-    Qt5::Widgets
+    Qt6::Widgets
   PUBLIC
     database-core
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Network
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Network
+    Qt6::Core5Compat
+
 )
 
 if (ENABLE_SCID_SUPPORT)
@@ -461,12 +464,12 @@ target_link_libraries(gui
     qt_config
     eco
     quazip
-    Qt5::PrintSupport
-    Qt5::Svg
+    Qt6::PrintSupport
+    Qt6::Svg
   PUBLIC
     database
-    Qt5::Widgets
-    Qt5::Xml
+    Qt6::Widgets
+    Qt6::Xml
 )
 
 if (ENABLE_SOUNDS)
@@ -474,7 +477,7 @@ if (ENABLE_SOUNDS)
     PRIVATE
       USE_SOUND
   )
-  target_link_libraries(gui PRIVATE Qt5::Multimedia)
+  target_link_libraries(gui PRIVATE Qt6::Multimedia)
   if (UNIX AND NOT APPLE)
     # on Linux QtMultimedia links to pulseaudio
     find_package(PulseAudio REQUIRED) 
@@ -491,6 +494,6 @@ if (ENABLE_TTS)
     PRIVATE
       USE_SPEECH
   )
-  target_link_libraries(gui PRIVATE Qt5::TextToSpeech)
+  target_link_libraries(gui PRIVATE Qt6::TextToSpeech)
 endif()
 

--- a/src/database/polyglotdatabase.cpp
+++ b/src/database/polyglotdatabase.cpp
@@ -22,7 +22,7 @@ using namespace  chessx;
 
 #define MAX_COUNT 16384
 
-struct key_compare : std::__binary_function< const book_entry&, const book_entry&, bool >
+struct key_compare
 {
     bool operator()( const book_entry& a, const book_entry& b ) const
     {

--- a/src/quazip/CMakeLists.txt
+++ b/src/quazip/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(quazip
     qt_config
   PUBLIC
     ZLIB::ZLIB
-    Qt5::Core
+    Qt6::Core
+    Qt6::Core5Compat
 )
 

--- a/src/quazip/qt6compat.h
+++ b/src/quazip/qt6compat.h
@@ -1,0 +1,58 @@
+#ifndef QT6COMPAT_H
+#define QT6COMPAT_H
+
+#include <QtGlobal>
+
+#ifdef USE_SOUND
+#if QT_VERSION < 0x060000
+#include <QSound>
+#else
+#include <QSoundEffect>
+class QSound : public QSoundEffect {
+public:
+    QSound(const QString& url) : QSoundEffect()
+    {
+        setSource(QUrl(url));
+    }
+    void play()
+    {
+        QSoundEffect::play();
+    }
+    static void play(const QString& url)
+    {
+        static QSoundEffect effect;
+        effect.setSource(QUrl(url));
+        effect.play();
+    }
+};
+#endif
+#endif
+
+#if QT_VERSION < 0x060000
+#include <QTextCodec>
+#define SET_CODEC_UTF8(s) \
+    QTextCodec* textCodec = QTextCodec::codecForName("utf8"); \
+    if(textCodec) s.setCodec(textCodec);
+#define SET_CODEC_LATIN1(s) \
+    QTextCodec* textCodec = QTextCodec::codecForName("ISO 8859-1"); \
+    if(textCodec) s.setCodec(textCodec);
+#else
+#include <QStringConverter>
+#define SET_CODEC_UTF8(s)   s.setEncoding(QStringConverter::Utf8);
+#define SET_CODEC_LATIN1(s) s.setEncoding(QStringConverter::Latin1);
+#endif
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QtCore/QString>
+constexpr auto SkipEmptyParts = QString::SkipEmptyParts;
+#else
+using Qt::SkipEmptyParts;
+#endif
+
+#if QT_VERSION < 0x060000
+#define EVENT_POSITION(event) (event)->pos()
+#else
+#define EVENT_POSITION(event) (event)->position().toPoint()
+#endif
+
+#endif // QT6COMPAT_H


### PR DESCRIPTION
This builds on the fantastic work of @additional-pumpkin,
Supercedes / Closes PR #90 and PR #91 

Specifically, I removed the obsolete/deprecated/removed `std:__binary_function`  template, as that is now handled entirely by the compiler as of C++17.

I also had to modify the ZLIB config in chessx.pro, as the default config wasn't building/linking correctly; I haven't messed with QT programming, or Windows linking/ABI in many years, so I could have missed something, but it was looking for extern's that didn't exist in the zlib libraries. (quazipfile.o was referencing `__imp_z_gzflush`, `__imp_z_gzread`, `__imp_z_gzwrite`, etc, that I couldn't find anywhere. 

Worth noting I tried first without installing external zlib, and also with external zlib, same problem, and the external zlib build didn't have the referenced implementation functions, either.