### PR TITLE
std::__binary_function doesn't exist

### DIFF
--- a/src/database/polyglotdatabase.cpp
+++ b/src/database/polyglotdatabase.cpp
@@ -22,7 +22,7 @@ using namespace  chessx;
 
 #define MAX_COUNT 16384
 
-struct key_compare : std::__binary_function< const book_entry&, const book_entry&, bool >
+struct key_compare : std::binary_function< const book_entry&, const book_entry&, bool >
 {
     bool operator()( const book_entry& a, const book_entry& b ) const
     {


### PR DESCRIPTION
I don't see a `std::__binary_function` here: https://en.cppreference.com/w/cpp/utility/functional/binary_function, and I get a compilation error for `std::__binary_function`:

```
../src/database/polyglotdatabase.cpp:25:44: error: expected template-name before ‘<’ token
   25 | struct key_compare : std::__binary_function< const book_entry&, const book_entry&, bool >
      |                                            ^
```