### PR TITLE
QJsonValue::toInteger doesn't exist

### DIFF
--- a/src/dialogs/tournamentselectiondialog.cpp
+++ b/src/dialogs/tournamentselectiondialog.cpp
@@ -44,7 +44,7 @@ void TournamentSelectionDialog::fill()
             qint64 startsAt = now.toMSecsSinceEpoch() + 1;
             foreach(QJsonValue round, rounds)
             {
-                startsAt = std::min(round.toObject().value("startsAt").toInteger(), startsAt);
+                startsAt = std::min(static_cast<qint64>(round.toObject().value("startsAt").toInt()), startsAt);
             }
             QTableWidget* w = ui->tournements;
             if ((startsAt <= now.toMSecsSinceEpoch()) && !name.isEmpty() && !id.isEmpty())


### PR DESCRIPTION
In qt-6 it exists: https://doc.qt.io/qt-6/qjsonvalue.html#toInteger, but in qt-5, it is toInt and returns "int" (not qint64): https://doc.qt.io/qt-5/qjsonvalue.html#toInt.