### PR TITLE
QStringList has no member named "remove"

### DIFF
--- a/src/database/annotation.cpp
+++ b/src/database/annotation.cpp
@@ -17,7 +17,7 @@ void Annotation::toggle(const QString& e)
     int n = l.indexOf(e);
     if (n>=0)
     {
-        l.remove(n);
+        l.removeAt(n);
     }
     else
     {
@@ -32,7 +32,7 @@ void Annotation::removeOne(const QRegularExpression& re)
     int n = l.indexOf(re);
     if (n>=0)
     {
-        l.remove(n);
+        l.removeAt(n);
     }
     annotation = l.join(',');
 }


### PR DESCRIPTION
https://doc.qt.io/qt-5/qstringlist-members.html

It would have gotten this functionality from QList presumably, but that class also doesn't have remove: https://doc.qt.io/qt-5/qlist.html

QT3 had this functionality:
https://documentation.help/Qt-3.0.5/qstringlist.html (through the QValueList object: https://documentation.help/Qt-3.0.5/qvaluelist.html). Qt 4 removed it in favor of removeAt and removeAll. Qt5 retained this removal, but QT 6 appears to have added it back:

https://doc.qt.io/qt-6/qstringlist-members.html