### PR TITLE
std::memcmp is defined in <cstring>

### DIFF
--- a/src/database/bitboard.cpp
+++ b/src/database/bitboard.cpp
@@ -13,6 +13,7 @@
 #include "square.h"
 #include "bitfind.h"
 #include <string.h>
+#include <cstring>
 
 #ifdef _MSC_VER
 #include <intrin.h>


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/string/byte/memcpy says, `Defined in header <cstring>` and my compiler agrees.