### PR TITLE
change struct `key_compare` to compile on gcc-14 on fedora 40

### DIFF
--- a/src/database/polyglotdatabase.cpp
+++ b/src/database/polyglotdatabase.cpp
@@ -22,7 +22,7 @@ using namespace  chessx;
 
 #define MAX_COUNT 16384
 
-struct key_compare : std::__binary_function< const book_entry&, const book_entry&, bool >
+struct key_compare
 {
     bool operator()( const book_entry& a, const book_entry& b ) const
     {


### PR DESCRIPTION
Fedora 40 build on gcc-14.x failed when compiling polyglotdatabase.cpp There is no need to inherit the deprecated std::binary_function.

A simple functor class is OK here (and used only in this file so no problem) and should work with any environment and compiler.

Same error occurs on fc-38/39 and gcc-13.x