### PR TITLE
analysis.cpp - make first move bold in analysis

### DIFF
--- a/src/database/analysis.cpp
+++ b/src/database/analysis.cpp
@@ -233,6 +233,8 @@ QString Analysis::toString(const BoardX& board, bool hideLines) const
     QString moveText;
     if(!hideLines)
     {
+        bool atLineStart = true;
+
         foreach(Move move, variation())
         {
             if(whiteToMove)
@@ -243,8 +245,22 @@ QString Analysis::toString(const BoardX& board, bool hideLines) const
             {
                 moveText += QString::number(moveNo++) + "... ";
             }
+
+            if(atLineStart)
+            {
+               moveText += "<b>";
+            }
+
             moveText += testBoard.moveToSan(move, true);
+
+            if(atLineStart)
+            {
+               moveText += "</b>";
+               atLineStart = false;
+            }
+
             moveText += " ";
+
             testBoard.doMove(move);
             whiteToMove = !whiteToMove;
         }


### PR DESCRIPTION
When analysis widget displays multi-line analysis it's easier to read the suggested first move of each line when it is in bold font.

This commit does just that.