### PR TITLE
Fix a Crash: check for invalid square at isAttackedBy() (bitboard.h)

### DIFF
--- a/src/database/bitboard.h
+++ b/src/database/bitboard.h
@@ -378,6 +378,10 @@ const unsigned int bb_ShiftL45[64] =
 
 inline bool BitBoard::isAttackedBy(const unsigned int color, chessx::Square square) const
 {
+    if(square == chessx::InvalidSquare)
+    {
+        return 0;
+    }
     if(bb_PawnAttacks[color ^ 1][square] & m_pawns & m_occupied_co[color])
     {
         return 1;


### PR DESCRIPTION
This commit Fixes the following crash scenario:

In Menus:
Click Edit | Setup Position...
Click Clear
Click on White King
CRASH

This commit checks in advance for InvalidSquare in function is AttackedBy().

The crash was: If a King is removed its square is set to InvalidSquare, Later when checking if that square is attacked we have a crash of accessing index beyond the board size.