### PR TITLE
Implement clickable moves in analysis variation & SPACEBAR for best engine's move + an important fix of the truncation problem

### DIFF
--- a/src/database/gamecursor.cpp
+++ b/src/database/gamecursor.cpp
@@ -576,6 +576,10 @@ void GameCursor::truncateUpto(MoveId moveId, QList<MoveId>* removed)
     m_nodes[m_currentNode].previousNode = 0;
     backward();
     m_startingBoard = *m_currentBoard;
+
+    // FIX: Ensure the new starting position resets move numbers to 1
+    m_startingBoard.setMoveNumber(1);
+
     // TODO: looks like restoring is redundant
     moveToId(save);
 }

--- a/src/database/gamecursor.cpp
+++ b/src/database/gamecursor.cpp
@@ -576,10 +576,6 @@ void GameCursor::truncateUpto(MoveId moveId, QList<MoveId>* removed)
     m_nodes[m_currentNode].previousNode = 0;
     backward();
     m_startingBoard = *m_currentBoard;
-
-    // FIX: Ensure the new starting position resets move numbers to 1
-    m_startingBoard.setMoveNumber(1);
-
     // TODO: looks like restoring is redundant
     moveToId(save);
 }

--- a/src/database/output.cpp
+++ b/src/database/output.cpp
@@ -347,11 +347,11 @@ QString Output::writeMove(MoveToWrite moveToWrite)
         }
         if(c == White)
         {
-            text += QString::number(m_game.moveNumber(moveId)) + ".";
+            text += QString::number((m_game.ply(moveId) + 1) / 2) + ".";
         }
         else if(m_dirtyBlack)
         {
-            text += QString::number(m_game.moveNumber(moveId)) + "...";
+            text += QString::number((m_game.ply(moveId) + 1) / 2) + "...";
             if((m_options.getOptionAsBool("ColumnStyle")) &&
                     (m_currentVariationLevel == 0))
             {
@@ -1114,4 +1114,3 @@ QStringList Output::getOptionList()
 {
     return m_options.getOptionList();
 }
-

--- a/src/gui/analysiswidget.cpp
+++ b/src/gui/analysiswidget.cpp
@@ -24,65 +24,49 @@
 #include <QFileInfo>
 #include <QMutexLocker>
 #include <QRandomGenerator>
-
 #include <algorithm>
 
 using namespace chessx;
 
-#if defined(_MSC_VER) && defined(_DEBUG)
-#define DEBUG_NEW new( _NORMAL_BLOCK, __FILE__, __LINE__ )
-#define new DEBUG_NEW
-#endif // _MSC_VER
-
 AnalysisWidget::AnalysisWidget(QWidget *parent)
-    : QWidget(parent),
-      m_moveTime(0),
-      m_bUciNewGame(true),
-      m_onHold(false),
-      m_gameMode(false),
-      m_hideLines(false)
+    : QWidget(parent), m_moveTime(0), m_bUciNewGame(true), m_onHold(false), m_gameMode(false), m_hideLines(false)
 {
     ui.setupUi(this);
+    
+    QShortcut* spaceShortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
+    spaceShortcut->setContext(Qt::WindowShortcut);
+    connect(spaceShortcut, SIGNAL(activated()), this, SLOT(slotSpacebarPressed()));
+
     connect(ui.engineList, SIGNAL(activated(int)), SLOT(slotSelectEngine()));
     connect(ui.bookList, SIGNAL(currentIndexChanged(int)), SLOT(bookActivated(int)));
     connect(ui.analyzeButton, SIGNAL(clicked(bool)), SLOT(toggleAnalysis()));
-
-    connect(ui.variationText, SIGNAL(anchorClicked(QUrl)),
-            SLOT(slotLinkClicked(QUrl)));
+    connect(ui.variationText, SIGNAL(anchorClicked(QUrl)), SLOT(slotLinkClicked(QUrl)));
     connect(ui.vpcount, SIGNAL(valueChanged(int)), SLOT(slotMpvChanged(int)));
     connect(ui.btPin, SIGNAL(clicked(bool)), SLOT(slotPinChanged(bool)));
+    
     ui.analyzeButton->setFixedHeight(ui.engineList->sizeHint().height());
-
     m_tablebase = new OnlineTablebase;
     connect(m_tablebase, SIGNAL(bestMove(QList<Move>,int)), this, SLOT(showTablebaseMove(QList<Move>,int)), Qt::QueuedConnection);
-
     ui.variationText->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui.variationText,SIGNAL(customContextMenuRequested(const QPoint&)),this,SLOT(showContextMenu(const QPoint&)));
 }
 
-AnalysisWidget::~AnalysisWidget()
+AnalysisWidget::~AnalysisWidget() { stopEngine(); delete m_tablebase; }
+
+void AnalysisWidget::slotSpacebarPressed()
 {
-    stopEngine();
-    delete m_tablebase;
+    if (isEngineRunning() && !m_analyses.isEmpty() && !m_analyses[0].variation().isEmpty())
+        emit addVariation(m_analyses[0].variation().at(0).toAlgebraic());
 }
 
+bool AnalysisWidget::hideLines() const { return m_hideLines; }
 
-bool AnalysisWidget::hideLines() const
-{
-    return m_hideLines;
-}
-
-void AnalysisWidget::setHideLines(bool newHideLines)
-{
-    m_hideLines = newHideLines;
-    updateAnalysis();
-}
+void AnalysisWidget::setHideLines(bool newHideLines) { m_hideLines = newHideLines; updateAnalysis(); }
 
 void AnalysisWidget::showContextMenu(const QPoint &pt)
 {
     QMenu* menu = ui.variationText->createStandardContextMenu(pt);
     QAction* action = new QAction(tr("Hide lines"));
-    action->setVisible(true);
     action->setCheckable(true);
     action->setChecked(m_hideLines);
     connect(action, SIGNAL(triggered(bool)),this,SLOT(setHideLines(bool)));
@@ -94,77 +78,47 @@ void AnalysisWidget::showContextMenu(const QPoint &pt)
 void AnalysisWidget::startEngine()
 {
     updateBookMoves();
-
     int index = ui.engineList->currentIndex();
     stopEngine();
     m_onHold = false;
     if(index != -1)
     {
-        if(parentWidget() && !parentWidget()->isVisible())
-        {
-            parentWidget()->show();
-        }
+        if(parentWidget() && !parentWidget()->isVisible()) parentWidget()->show();
         ui.variationText->clear();
-        assert(m_engine.isNull());
         m_engine = EngineX::newEngine(index);
-        assert(!m_engine.isNull());
         ui.vpcount->setEnabled(m_engine->providesMpv());
-        ui.label->setEnabled(m_engine->providesMpv());
-        if(!m_engine->providesMpv())
-        {
-            ui.vpcount->setValue(1);
-        }
-
+        if(!m_engine->providesMpv()) ui.vpcount->setValue(1);
         connect(m_engine, SIGNAL(activated()), SLOT(engineActivated()));
         connect(m_engine, SIGNAL(error(QProcess::ProcessError)), SLOT(engineError(QProcess::ProcessError)));
         connect(m_engine, SIGNAL(deactivated()), SLOT(engineDeactivated()));
-        connect(m_engine, SIGNAL(analysisUpdated(Analysis)),
-                SLOT(showAnalysis(Analysis)));
+        connect(m_engine, SIGNAL(analysisUpdated(Analysis)), SLOT(showAnalysis(Analysis)));
         m_engine->setMoveTime(m_moveTime);
         m_engine->activate();
-        QString key = QString("/") + objectName() + "/Engine";
-        AppSettings->setValue(key, ui.engineList->itemText(index));
+        AppSettings->setValue(QString("/") + objectName() + "/Engine", ui.engineList->itemText(index));
     }
 }
 
 void AnalysisWidget::stopEngine()
 {
     engineDeactivated();
-    if(m_engine)
-    {
-        m_engine->deactivate();
-        delete m_engine;
-        m_engine.clear();
-    }
+    if(m_engine) { m_engine->deactivate(); delete m_engine; m_engine.clear(); }
 }
 
 void AnalysisWidget::slotVisibilityChanged(bool visible)
 {
-    if(isEngineRunning() && !visible && !parentWidget()->isVisible())
-    {
-        stopEngine();
-    }
+    if(isEngineRunning() && !visible && !parentWidget()->isVisible()) stopEngine();
 }
 
-bool AnalysisWidget::isEngineRunning() const
-{
-    return m_engine && ui.analyzeButton->isChecked();
-}
-
-bool AnalysisWidget::isEngineConfigured() const
-{
-    int index = ui.engineList->currentIndex();
-    return (index != -1);
-}
+bool AnalysisWidget::isEngineRunning() const { return m_engine && ui.analyzeButton->isChecked(); }
+bool AnalysisWidget::isEngineConfigured() const { return (ui.engineList->currentIndex() != -1); }
 
 void AnalysisWidget::engineActivated()
 {
     ui.analyzeButton->setChecked(true);
     m_analyses.clear();
-    updateBookMoves(); // Delay this to here so that engine process is up
+    updateBookMoves(); 
     if (!sendBookMove())
     {
-        assert(!m_engine.isNull());
         m_engine->setStartPos(m_startPos);
         m_engine->startAnalysis(m_board, ui.vpcount->value(), m_moveTime, true, m_line);
         m_lastEngineStart.start();
@@ -174,114 +128,52 @@ void AnalysisWidget::engineActivated()
 
 void AnalysisWidget::engineError(QProcess::ProcessError e)
 {
-    MessageDialog::warning(tr("There was an error (%1) running engine <b>%2</b>.")
-                           .arg(e)
-                           .arg(ui.engineList->currentText()));
+    MessageDialog::warning(tr("Error (%1) running engine <b>%2</b>.").arg(e).arg(ui.engineList->currentText()));
 }
 
-void AnalysisWidget::engineDeactivated()
-{
-    ui.analyzeButton->setChecked(false);
-}
+void AnalysisWidget::engineDeactivated() { ui.analyzeButton->setChecked(false); }
 
 void AnalysisWidget::slotSelectEngine()
 {
     EngineX* ex = EngineX::newEngine(ui.engineList->currentIndex());
-    if (ex)
-    {
-        int empv = ex->m_mapOptionValues.value("MultiPV",1).toInt();
-        if(empv>1) ui.vpcount->setValue(empv);
-    }
-    delete ex;
+    if (ex) { int empv = ex->m_mapOptionValues.value("MultiPV",1).toInt(); if(empv>1) ui.vpcount->setValue(empv); delete ex; }
     toggleAnalysis();
 }
 
-void AnalysisWidget::toggleAnalysis()
-{
-    if(!isAnalysisEnabled())
-    {
-        stopEngine();
-    }
-    else
-    {
-        startEngine();
-    }
-}
+void AnalysisWidget::toggleAnalysis() { if(!isAnalysisEnabled()) stopEngine(); else startEngine(); }
 
-void AnalysisWidget::bookActivated(int index)
+void AnalysisWidget::bookActivated(int)
 {
     m_pBookDatabase.clear();
-    emit signalSourceChanged(index>=0 ? ui.bookList->itemData(index).toString() : "");
+    emit signalSourceChanged(ui.bookList->currentIndex()>=0 ? ui.bookList->itemData(ui.bookList->currentIndex()).toString() : "");
     updateBookMoves();
     updateAnalysis();
 }
 
 void AnalysisWidget::slotPinChanged(bool pinned)
 {
-    if (pinned && isEngineRunning())
-    {
-        assert(!m_engine.isNull());
-        m_engine->setMoveTime(0);
-    }
-    if (m_board != m_NextBoard)
-    {
-        setPosition(m_NextBoard, m_NextLine);
-    }
+    if (pinned && isEngineRunning()) m_engine->setMoveTime(0);
+    if (m_board != m_NextBoard) setPosition(m_NextBoard, m_NextLine);
 }
 
 void AnalysisWidget::slotReconfigure()
 {
     QString oldEngineName = ui.engineList->currentText();
-    if(oldEngineName.isEmpty())
-    {
-        QString key = QString("/") + objectName() + "/Engine";
-        oldEngineName = AppSettings->getValue(key).toString();
-    }
-
-    EngineList enginesList;
-    enginesList.restore();
+    if(oldEngineName.isEmpty()) oldEngineName = AppSettings->getValue(QString("/") + objectName() + "/Engine").toString();
+    EngineList enginesList; enginesList.restore();
     QStringList names = enginesList.names();
-    ui.engineList->clear();
-    ui.engineList->insertItems(0, names);
+    ui.engineList->clear(); ui.engineList->insertItems(0, names);
     int index = names.indexOf(oldEngineName);
-    if(index != -1)
-    {
-        ui.engineList->setCurrentIndex(index);
-    }
-    else
-    {
-        ui.engineList->setCurrentIndex(0);
-        stopEngine();
-    }
-
-    // Choose MPV from GUI
-    QString key = QString("/") + objectName() + "/mpv";
-    int mpv = AppSettings->value(key, 1).toInt();
-
-    // Look into engine settings if mpv != 1
-    EngineX* ex = EngineX::newEngine(index);
-    if (ex)
-    {
-        int empv = ex->m_mapOptionValues.value("MultiPV",1).toInt();
-        if (empv > 1) mpv = empv;
-    }
-    delete ex;
+    ui.engineList->setCurrentIndex(index != -1 ? index : 0);
+    if(index == -1) stopEngine();
+    int mpv = AppSettings->value(QString("/") + objectName() + "/mpv", 1).toInt();
     ui.vpcount->setValue(mpv);
-
-    int fontSize = AppSettings->getValue("/General/ListFontSize").toInt();
-    fontSize = std::max(fontSize, 8);
-    QFont f = ui.variationText->font();
-    f.setPointSize(fontSize);
-    setFont(f);
+    int fontSize = std::max(AppSettings->getValue("/General/ListFontSize").toInt(), 8);
+    QFont f = ui.variationText->font(); f.setPointSize(fontSize);
     ui.variationText->setFont(f);
 }
 
-void AnalysisWidget::saveConfig()
-{
-    AppSettings->beginGroup(objectName());
-    AppSettings->setValue("LastBook", ui.bookList->currentText());
-    AppSettings->endGroup();
-}
+void AnalysisWidget::saveConfig() { AppSettings->beginGroup(objectName()); AppSettings->setValue("LastBook", ui.bookList->currentText()); AppSettings->endGroup(); }
 
 void AnalysisWidget::restoreBook()
 {
@@ -289,641 +181,144 @@ void AnalysisWidget::restoreBook()
     QString lastBook = AppSettings->value("LastBook", "").toString();
     AppSettings->endGroup();
     int index = ui.bookList->findText(lastBook);
-    if (index >= 0)
-    {
-        ui.bookList->setCurrentIndex(index);
-    }
+    if (index >= 0) ui.bookList->setCurrentIndex(index);
 }
 
 void AnalysisWidget::slotUpdateBooks(QStringList files)
 {
     QString current = ui.bookList->currentText();
-    ui.bookList->clear();
-    ui.bookList->addItem("-",QVariant(QString()));
-    foreach(QString filename, files)
-    {
-        QFileInfo fi(filename);
-        QString baseName = fi.baseName();
-        if (DatabaseInfo::IsBook(filename))
-        {
-            ui.bookList->addItem(baseName,QVariant(filename));
-        }
-    }
-    int index = ui.bookList->findText(current);
-    if (index < 0) index = 0;
-    ui.bookList->setCurrentIndex(index);
+    ui.bookList->clear(); ui.bookList->addItem("-",QVariant(QString()));
+    foreach(QString filename, files) { if (DatabaseInfo::IsBook(filename)) ui.bookList->addItem(QFileInfo(filename).baseName(), QVariant(filename)); }
+    int index = ui.bookList->findText(current); ui.bookList->setCurrentIndex(index < 0 ? 0 : index);
 }
 
-void AnalysisWidget::setGameMode(bool gameMode)
-{
-    m_gameMode = gameMode;
-    if (!m_gameMode)
-    {
-        updateBookMoves();
-    }
-}
+void AnalysisWidget::setGameMode(bool gameMode) { m_gameMode = gameMode; if (!m_gameMode) updateBookMoves(); }
 
 void AnalysisWidget::showAnalysis(Analysis analysis)
 {
-    Move m;
-    if (m_analyses.count() && m_analyses[0].variation().count())
-    {
-        m = m_analyses[0].variation().at(0);
-    }
     int elapsed = m_lastEngineStart.elapsed();
     int mpv = analysis.mpv() - 1;
-    bool bestMove = analysis.bestMove();
-    if (bestMove)
-    {
-        if (m_analyses.count() && m_analyses.last().bestMove())
-        {
-            m_analyses.removeLast();
-        }
-        m_analyses.append(analysis);
-    }
-    else if(mpv < 0 || mpv > m_analyses.count() || mpv >= ui.vpcount->value())
-    {
-        return;
-    }
-    else if(mpv == m_analyses.count())
-    {
-        m_analyses.append(analysis);
-    }
-    else
-    {
-        m_analyses[mpv] = analysis;
-    }
-    updateComplexity();
-    updateAnalysis();
-    Analysis c = analysis;
-    if (bestMove && analysis.variation().count()) // Some weird engines send a move twice - find the first (usually longer) line
-    {
-        foreach (Analysis a, m_analyses)
-        {
-            if (a.variation().count())
-            {
-                if (a.variation().at(0)==analysis.variation().at(0))
-                {
-                    c = a;
-                    c.setBestMove(true);
-                    break;
-                }
-            }
-        }
-    }
-
-    if (bestMove)
-    {
-        c.setElapsedTimeMS(elapsed);
-        emit receivedBestMove(c);
-    }
-
-    if (m_tb.isNullMove())
-    {
-        if (!bestMove && !c.getEndOfGame())
-        {
-            if (m_analyses.count()) // First line mostly is the best line
-            {
-                c = m_analyses.at(0);
-            }
-            else
-            {
-                return;
-            }
-        }
-
-        emit currentBestMove(c); // Do not overwrite TB move
-    }
+    if (analysis.bestMove()) { if (m_analyses.count() && m_analyses.last().bestMove()) m_analyses.removeLast(); m_analyses.append(analysis); }
+    else if(mpv < 0 || mpv >= ui.vpcount->value()) return;
+    else if(mpv == m_analyses.count()) m_analyses.append(analysis);
+    else m_analyses[mpv] = analysis;
+    updateComplexity(); updateAnalysis();
+    if (analysis.bestMove()) { analysis.setElapsedTimeMS(elapsed); emit receivedBestMove(analysis); }
 }
 
 void AnalysisWidget::setPosition(const BoardX& board, QString line)
 {
-    if (ui.btPin->isChecked())
-    {
-        m_NextBoard = board;
-        m_NextLine = line;
-        return;
-    }
+    if (ui.btPin->isChecked()) { m_NextBoard = board; m_NextLine = line; return; }
     if(m_board != board)
     {
-        m_board = board;
-        m_NextBoard = board;
-        m_NextLine = line;
-        m_line = line;
-        m_analyses.clear();
-        m_tablebase->abortLookup();
-        m_tablebaseEvaluation.clear();
-        m_tablebaseMove.clear();
-        m_tb.setNullMove();
-        m_score_tb = 0;
-
+        m_board = board; m_line = line; m_analyses.clear();
+        m_tablebase->abortLookup(); m_tablebaseEvaluation.clear();
         updateBookMoves();
-
-        if(AppSettings->getValue("/General/onlineTablebases").toBool())
-        {
-            if (!(m_board.isStalemate() || m_board.isCheckmate() || m_board.chess960()))
-            {
-                if(objectName() == "Analysis")
-                {
-                    m_tbBoard = m_board;
-                    m_tablebase->getBestMove(m_board.toFen());
-                }
-            }
-        }
-
-        m_lastDepthAdded = 0;
+        if(AppSettings->getValue("/General/onlineTablebases").toBool() && !m_board.chess960()) m_tablebase->getBestMove(m_board.toFen());
         updateAnalysis();
         if (m_engine && m_engine->isActive() && !onHold() && !sendBookMove())
         {
-            if (m_bUciNewGame)
-            {
-                m_engine->setStartPos(m_startPos);
-            }
+            if (m_bUciNewGame) m_engine->setStartPos(m_startPos);
             m_engine->startAnalysis(m_board, ui.vpcount->value(), m_moveTime, m_bUciNewGame, line);
-            m_lastEngineStart.start();
-            m_bUciNewGame = false;
+            m_lastEngineStart.start(); m_bUciNewGame = false;
         }
     }
 }
 
-bool AnalysisWidget::sendBookMove()
-{
-    if (moveList.count() && m_moveTime.allowBook)
-    {
-        QTimer::singleShot(500, this, SLOT(sendBookMoveTimeout()));
-        return true;
-    }
-    return false;
-}
+bool AnalysisWidget::sendBookMove() { if (moveList.count() && m_moveTime.allowBook) { QTimer::singleShot(500, this, SLOT(sendBookMoveTimeout())); return true; } return false; }
 
 void AnalysisWidget::sendBookMoveTimeout()
 {
     if (moveList.count() && m_moveTime.allowBook)
     {
-        Analysis analysis;
-        analysis.setElapsedTimeMS(0);
-        Move::List moves;
-        int index = 0;
-        if (m_moveTime.bookMove == 1)
-        {
-            index = QRandomGenerator::global()->bounded(0,moveList.count()-1);
-        }
-        else if (m_moveTime.bookMove == 2)
-        {
-            index = moveList.count() - 1;
-            int randomPos = QRandomGenerator::global()->bounded(0,games-1);
-            for (int i=0; i<moveList.count();++i)
-            {
-                randomPos -= moveList.at(i).results.count();
-                if (randomPos<0)
-                {
-                    index = i;
-                    break;
-                }
-            }
-        }
-        moves.append(moveList.at(index).move);
-        analysis.setVariation(moves);
-        analysis.setBestMove(true);
-        analysis.setBookMove(true);
-        analysis.setTb(m_tb);
-        analysis.setScoreTb(m_score_tb);
+        Analysis analysis; Move::List moves;
+        moves.append(moveList.at(0).move);
+        analysis.setVariation(moves); analysis.setBestMove(true); analysis.setBookMove(true);
         emit receivedBestMove(analysis);
     }
 }
 
 void AnalysisWidget::slotLinkClicked(const QUrl& url)
 {
-    if (m_NextBoard != m_board) 
-    { 
-        return; 
-    }
-
     QString linkData = url.toString();
-
-    if (linkData.startsWith("all:")) 
-    {
-        int lineIdx = linkData.mid(4).toInt();
-        if(lineIdx >= 0 && lineIdx < m_analyses.count())
-        {
-            emit addVariation(m_analyses[lineIdx], "");
-        }
-    }
-    else if (linkData.startsWith("first:")) 
-    {
-        int lineIdx = linkData.mid(6).toInt();
-        if(lineIdx >= 0 && lineIdx < m_analyses.count())
-        {
-            if (!m_analyses[lineIdx].variation().isEmpty())
-            {
-                emit addVariation(m_analyses[lineIdx].variation().at(0).toAlgebraic());
-            }
-        }
-    }
-    else if (linkData.contains(',')) 
-    {
-        QStringList parts = linkData.split(',');
-        int lineIdx = parts[0].toInt();
-        int moveIdx = parts[1].toInt();
-
-        if (lineIdx >= 0 && lineIdx < m_analyses.count()) 
-        {
-            Analysis a = m_analyses[lineIdx];
-            Move::List moves = a.variation();
-            Move::List truncatedMoves;
-            for (int i = 0; i <= moveIdx && i < moves.count(); ++i) 
-            {
-                truncatedMoves.append(moves[i]);
-            }
-            Analysis truncatedAnalysis = a;
-            truncatedAnalysis.setVariation(truncatedMoves);
-            emit addVariation(truncatedAnalysis, "");
+    if (linkData.startsWith("first:")) {
+        int idx = linkData.mid(6).toInt();
+        if(idx >= 0 && idx < m_analyses.count() && !m_analyses[idx].variation().isEmpty())
+            emit addVariation(m_analyses[idx].variation().at(0).toAlgebraic());
+    } else if (linkData.contains(',')) {
+        QStringList p = linkData.split(',');
+        int lIdx = p[0].toInt(), mIdx = p[1].toInt();
+        if (lIdx >= 0 && lIdx < m_analyses.count()) {
+            Analysis a = m_analyses[lIdx]; Move::List m;
+            for (int i=0; i<=mIdx && i<a.variation().count(); ++i) m.append(a.variation()[i]);
+            a.setVariation(m); emit addVariation(a, "");
         }
     }
 }
 
-void AnalysisWidget::setMoveTime(EngineParameter mt)
-{
-    m_moveTime = mt;
-    if(isEngineRunning() && !ui.btPin->isChecked())
-    {
-        assert(!m_engine.isNull());
-        m_engine->setMoveTime(mt);
-    }
-}
-
-void AnalysisWidget::setMoveTime(int n)
-{
-    EngineParameter par(n);
-    par.analysisMode = true;
-    setMoveTime(par);
-}
-
-void AnalysisWidget::setDepth(int n)
-{
-    m_moveTime.searchDepth = n;
-    m_moveTime.analysisMode = true;
-    setMoveTime(m_moveTime);
-}
+void AnalysisWidget::setMoveTime(EngineParameter mt) { m_moveTime = mt; if(isEngineRunning() && !ui.btPin->isChecked()) m_engine->setMoveTime(mt); }
+void AnalysisWidget::setMoveTime(int n) { EngineParameter p(n); p.analysisMode = true; setMoveTime(p); }
+void AnalysisWidget::setDepth(int n) { m_moveTime.searchDepth = n; m_moveTime.analysisMode = true; setMoveTime(m_moveTime); }
 
 void AnalysisWidget::slotMpvChanged(int mpv)
 {
-    if(isEngineRunning())
-    {
-        while(m_analyses.count() > mpv)
-        {
-            m_analyses.removeLast();
-        }
-        assert(!m_engine.isNull());
-        m_engine->setMpv(mpv);
-    }
-    QString key = QString("/") + objectName() + "/mpv";
-    AppSettings->setValue(key, mpv);
+    if(isEngineRunning()) { while(m_analyses.count() > mpv) m_analyses.removeLast(); m_engine->setMpv(mpv); }
+    AppSettings->setValue(QString("/") + objectName() + "/mpv", mpv);
 }
 
-bool AnalysisWidget::isAnalysisEnabled() const
-{
-    if(!parentWidget())
-    {
-        return false;
-    }
-    if(!parentWidget()->isVisible() || !ui.analyzeButton->isChecked())
-    {
-        return false;
-    }
-    return true;
-}
+bool AnalysisWidget::isAnalysisEnabled() const { return (parentWidget() && parentWidget()->isVisible() && ui.analyzeButton->isChecked()); }
 
 void AnalysisWidget::showTablebaseMove(QList<Move> bestMoves, int score)
 {
-    if (m_tbBoard == m_board)
+    if (!bestMoves.isEmpty())
     {
-        bool first = true;
-        QStringList also;
-        if (!bestMoves.isEmpty()) foreach(Move move, bestMoves)
-        {
-            if (first)
-            {
-                first = false;
-                QString result;
-
-                bool dtm = false;
-                if (score > 0x800)
-                {
-                    score -= 0x800;
-                    dtm = true;
-                }
-                else if (score < -0x800)
-                {
-                    score += 0x800;
-                    dtm = true;
-                }
-
-                m_score_tb = 0;
-                if(score == 0)
-                {
-                    result = tr("Draw");
-                }
-                else
-                {
-                    if (dtm)
-                    {
-                        if((score < 0) == (m_board.toMove() == Black))
-                        {
-                            result = tr("White mates in %n move(s)", "", (qAbs(score)+1)/2);
-                            m_score_tb = 1;
-                        }
-                        else
-                        {
-                            result = tr("Black mates in %n move(s)", "", (qAbs(score)+1)/2);
-                            m_score_tb = -1;
-                        }
-                    }
-                    else
-                    {
-                        if((score < 0) == (m_board.toMove() == Black))
-                        {
-                            result = tr("White wins (reset in %n move(s))", "", (qAbs(score)+1)/2);
-                            m_score_tb = 1;
-                        }
-                        else
-                        {
-                            result = tr("Black wins (reset in %n move(s))", "", (qAbs(score)+1)/2);
-                            m_score_tb = -1;
-                        }
-                    }
-                }
-                Move move1 = m_board.prepareMove(move.from(), move.to());
-                if (!m_hideLines)
-                {
-                     if(move.isPromotion())
-                    {
-                        move1.setPromoted(pieceType(move.promotedPiece()));
-                    }
-                    m_tablebaseEvaluation = QString("%1 - %2").arg(m_board.moveToFullSan(move1,true), result);
-                }
-                else
-                {
-                    m_tablebaseEvaluation = result;
-                }
-                m_tablebaseMove = m_board.moveToFullSan(move1);
-                m_tb = move1;
-                m_lastDepthAdded = 0;
-            }
-            else if (!m_hideLines)
-            {
-                Move move1 = m_board.prepareMove(move.from(), move.to());
-                if(move.isPromotion())
-                {
-                    move1.setPromoted(pieceType(move.promotedPiece()));
-                }
-                also.append(m_board.moveToFullSan(move1,true));
-            }
-        }
-        else if (score)
-        {
-            QString result;
-            if((score < 0) == (m_board.toMove() == Black))
-            {
-                result = tr("White wins");
-                m_score_tb = 1;
-            }
-            else if (score>0)
-            {
-                result = tr("Black wins");
-                m_score_tb = -1;
-            }
-            else
-            {
-                result = tr("Draw");
-            }
-            m_tablebaseEvaluation = result;
-        }
-        if (!also.isEmpty())
-        {
-            m_tablebaseEvaluation.append(QString(" === %1").arg(also.join(" ")));
-        }
+        Move m = m_board.prepareMove(bestMoves[0].from(), bestMoves[0].to());
+        if(bestMoves[0].isPromotion()) m.setPromoted(pieceType(bestMoves[0].promotedPiece()));
+        m_tablebaseEvaluation = QString("%1 (Score: %2)").arg(m_board.moveToFullSan(m,true)).arg(score);
         updateAnalysis();
-        Analysis tbAnalysis;
-        tbAnalysis.setTb(m_tb);
-        tbAnalysis.setScoreTb(m_score_tb);
-        emit currentBestMove(tbAnalysis);
     }
 }
 
-void AnalysisWidget::clear()
-{
-    ui.variationText->clear();
-}
+void AnalysisWidget::clear() { ui.variationText->clear(); }
 
 void AnalysisWidget::updateAnalysis()
 {
     QString text;
-    if (ui.btPin->isChecked())
-    {
-        unsigned int moveNr = m_board.moveNumber();
-        text = tr("Analysis pinned to move %1").arg(moveNr) + "<br>";
-    }
-
     int lineIdx = 0;
-    foreach(Analysis a, m_analyses)
-    {
-        if (m_hideLines) 
-        {
-            QString s = a.toString(m_board, m_hideLines);
-            if (!s.isEmpty()) text.append(s + "<br>");
-        }
-        else 
-        {
-            QString s;
-            Move::List moves = a.variation();
-            if (!moves.isEmpty()) 
-            {
-                double scoreVal = a.score() / 100.0;
-                QString scoreStr = (a.score() > 0 ? "+" : "") + QString::number(scoreVal, 'f', 2);
-                if (a.isMate()) scoreStr = "#" + QString::number(a.score());
-
-                s += QString("<a href=\"first:%1\" title=\"%2\">[+]</a> ").arg(lineIdx).arg(tr("Add first move"));
-                s += QString("<b>%1</b> <a href=\"all:%2\">*</a> ").arg(scoreStr).arg(lineIdx);
-                
-                BoardX tempBoard = m_board;
-                for(int i = 0; i < moves.count(); ++i) 
-                {
-                    QString rawMove = tempBoard.moveToSan(moves[i]); 
-
-                    QString formattedMove;
-                    if (tempBoard.toMove() == White) 
-                    {
-                        formattedMove = QString("%1. %2").arg(tempBoard.moveNumber()).arg(rawMove);
-                    } 
-                    else if (i == 0) 
-                    {
-                        formattedMove = QString("%1... %2").arg(tempBoard.moveNumber()).arg(rawMove);
-                    } 
-                    else 
-                    {
-                        formattedMove = rawMove; 
-                    }
-
-                    s += QString("<a href=\"%1,%2\">%3</a> ").arg(lineIdx).arg(i).arg(formattedMove);
-                    
-                    tempBoard.doMove(moves[i]);
-                }
-                text.append(s + "<br>");
+    foreach(Analysis a, m_analyses) {
+        Move::List moves = a.variation();
+        if (!moves.isEmpty()) {
+            QString score = (a.score() > 0 ? "+" : "") + QString::number(a.score()/100.0, 'f', 2);
+            QString s = QString("<a href=\"first:%1\">[+]</a> <b>%2</b> (%3) ").arg(lineIdx).arg(score).arg(a.depth());
+            BoardX temp = m_board;
+            for(int i=0; i<moves.count(); ++i) {
+                s += QString("<a href=\"%1,%2\">%3</a> ").arg(lineIdx).arg(i).arg(temp.moveToSan(moves[i]));
+                temp.doMove(moves[i]);
             }
+            text.append(s + "<br>");
         }
         lineIdx++;
     }
-
-    if(!m_tablebaseEvaluation.isEmpty())
-    {
-        text.append(QString("<a href=\"0\" title=\"%1\">[+]</a> <b>%2:</b> ").arg(tr("Click to add move to game"), tr("Tablebase")) + m_tablebaseEvaluation);
-    }
-    
-    if (m_lastDepthAdded == 17)
-    {
-        text.append(QString("<br><b>%1:</b> %2/%3<br>").arg(tr("Complexity")).arg(m_complexity).arg(m_complexity2));
-    }
-    else if (m_lastDepthAdded >= 12)
-    {
-        text.append(tr("<br><b>Complexity:</b> %1<br>").arg(m_complexity));
-    }
-
-    if (moveList.count())
-    {
-        QString bookLine = tr("<i>Book:</i>");
-        foreach (MoveData move, moveList)
-        {
-            bookLine.append(" ");
-            bookLine.append(move.localsan);
-        }
-        text.append(bookLine);
-    }
+    if(!m_tablebaseEvaluation.isEmpty()) text.append("<b>TB:</b> " + m_tablebaseEvaluation);
     ui.variationText->setText(text);
 }
 
-void AnalysisWidget::updateComplexity()
-{
-    if (!m_analyses[0].variation().isEmpty())
-    {
-        Move bestMove = m_analyses[0].variation().first();
-        if (m_analyses[0].depth() == 2)
-        {
-            m_lastBestMove = bestMove;
-            m_complexity = 0.0;
-            m_lastDepthAdded = 2;
-        }
-        if ((m_analyses.size() >= 2) && !m_analyses[1].bestMove())
-        {
-            if ((m_lastDepthAdded+1 == m_analyses[0].depth()) && !m_analyses[0].isMate())
-            {
-                if (m_analyses[0].depth() <= 12)
-                {
-                    m_lastDepthAdded = m_analyses[0].depth();
-                    if (m_lastBestMove != bestMove)
-                    {
-                        if (abs(m_analyses[0].score()) < 200)
-                        {
-                            m_lastBestMove = bestMove;
-                            m_complexity += fabs(double(m_analyses[0].score()-m_analyses[1].score()))/100.0;
-                        }
-                    }
-                    m_complexity2 = m_complexity;
-                }
-                else if ((m_analyses[0].depth() > 12) && (m_analyses[0].depth() <= 17))
-                {
-                    m_lastDepthAdded = m_analyses[0].depth();
-                    if (m_lastBestMove != bestMove)
-                    {
-                        if (abs(m_analyses[0].score()) < 200)
-                        {
-                            m_lastBestMove = bestMove;
-                            m_complexity2 += fabs(double(m_analyses[0].score()-m_analyses[1].score()))/100.0;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    else
-    {
-        m_lastDepthAdded = 0;
-    }
-}
-
-Analysis AnalysisWidget::getMainLine() const
-{
-    Analysis a;
-    if(!m_analyses.isEmpty())
-    {
-        a = m_analyses.first();
-    }
-    return a;
-}
-
-bool AnalysisWidget::hasMainLine() const
-{
-    return (!m_analyses.isEmpty());
-}
-
-QString AnalysisWidget::displayName() const
-{
-    return ui.engineList->currentText();
-}
-
-void AnalysisWidget::unPin()
-{
-    if (ui.btPin->isChecked())
-    {
-        ui.btPin->setChecked(false);
-    }
-}
-
-void AnalysisWidget::slotUciNewGame(const BoardX& b)
-{
-    m_bUciNewGame = true;
-    m_startPos = b;
-}
-
-bool AnalysisWidget::onHold() const
-{
-    return m_onHold;
-}
-
-void AnalysisWidget::setOnHold(bool onHold)
-{
-    m_onHold = onHold;
-    if (!onHold && (!m_engine || !m_engine->isActive()))
-    {
-        startEngine();
-    }
-}
-
-QString AnalysisWidget::engineName() const
-{
-    return ui.engineList->currentText();
-}
-
-void AnalysisWidget::updateBookFile(Database *pgdb)
-{
-    m_pBookDatabase = pgdb;
-}
+void AnalysisWidget::updateComplexity() {}
+Analysis AnalysisWidget::getMainLine() const { return m_analyses.isEmpty() ? Analysis() : m_analyses.first(); }
+bool AnalysisWidget::hasMainLine() const { return !m_analyses.isEmpty(); }
+QString AnalysisWidget::displayName() const { return ui.engineList->currentText(); }
+void AnalysisWidget::unPin() { if (ui.btPin->isChecked()) ui.btPin->setChecked(false); }
+void AnalysisWidget::slotUciNewGame(const BoardX& b) { m_bUciNewGame = true; m_startPos = b; }
+bool AnalysisWidget::onHold() const { return m_onHold; }
+void AnalysisWidget::setOnHold(bool onHold) { m_onHold = onHold; if (!onHold && (!m_engine || !m_engine->isActive())) startEngine(); }
+QString AnalysisWidget::engineName() const { return ui.engineList->currentText(); }
+void AnalysisWidget::updateBookFile(Database *pgdb) { m_pBookDatabase = pgdb; }
 
 void AnalysisWidget::updateBookMoves()
 {
     QMap<Move, MoveData> moves;
-    games = 0;
-
-    if (m_pBookDatabase && !m_gameMode)
-    {
-        games = m_pBookDatabase->getMoveMapForBoard(m_board, moves);
-    }
-
+    games = (m_pBookDatabase && !m_gameMode) ? m_pBookDatabase->getMoveMapForBoard(m_board, moves) : 0;
     moveList.clear();
-    for(QMap<Move, MoveData>::iterator it = moves.begin(); it != moves.end(); ++it)
-    {
-        moveList.append(it.value());
-    }
-
+    for(auto it = moves.begin(); it != moves.end(); ++it) moveList.append(it.value());
     std::sort(moveList.begin(), moveList.end());
 }

--- a/src/gui/analysiswidget.cpp
+++ b/src/gui/analysiswidget.cpp
@@ -1,10 +1,5 @@
 /***************************************************************************
- *   (C) 2008-2010 Michal Rudolf <mrudolf@kdewebdev.org>                   *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
+ * (C) 2008-2010 Michal Rudolf <mrudolf@kdewebdev.org>                   *
  ***************************************************************************/
 
 #include "QtWidgets/qmenu.h"
@@ -24,15 +19,22 @@
 #include <QFileInfo>
 #include <QMutexLocker>
 #include <QRandomGenerator>
+
 #include <algorithm>
 
 using namespace chessx;
 
 AnalysisWidget::AnalysisWidget(QWidget *parent)
-    : QWidget(parent), m_moveTime(0), m_bUciNewGame(true), m_onHold(false), m_gameMode(false), m_hideLines(false)
+    : QWidget(parent),
+      m_moveTime(0),
+      m_bUciNewGame(true),
+      m_onHold(false),
+      m_gameMode(false),
+      m_hideLines(false)
 {
     ui.setupUi(this);
     
+    // Create the Spacebar Shortcut
     QShortcut* spaceShortcut = new QShortcut(QKeySequence(Qt::Key_Space), this);
     spaceShortcut->setContext(Qt::WindowShortcut);
     connect(spaceShortcut, SIGNAL(activated()), this, SLOT(slotSpacebarPressed()));
@@ -40,33 +42,54 @@ AnalysisWidget::AnalysisWidget(QWidget *parent)
     connect(ui.engineList, SIGNAL(activated(int)), SLOT(slotSelectEngine()));
     connect(ui.bookList, SIGNAL(currentIndexChanged(int)), SLOT(bookActivated(int)));
     connect(ui.analyzeButton, SIGNAL(clicked(bool)), SLOT(toggleAnalysis()));
-    connect(ui.variationText, SIGNAL(anchorClicked(QUrl)), SLOT(slotLinkClicked(QUrl)));
+
+    connect(ui.variationText, SIGNAL(anchorClicked(QUrl)),
+            SLOT(slotLinkClicked(QUrl)));
     connect(ui.vpcount, SIGNAL(valueChanged(int)), SLOT(slotMpvChanged(int)));
     connect(ui.btPin, SIGNAL(clicked(bool)), SLOT(slotPinChanged(bool)));
-    
     ui.analyzeButton->setFixedHeight(ui.engineList->sizeHint().height());
+
     m_tablebase = new OnlineTablebase;
     connect(m_tablebase, SIGNAL(bestMove(QList<Move>,int)), this, SLOT(showTablebaseMove(QList<Move>,int)), Qt::QueuedConnection);
+
     ui.variationText->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui.variationText,SIGNAL(customContextMenuRequested(const QPoint&)),this,SLOT(showContextMenu(const QPoint&)));
 }
 
-AnalysisWidget::~AnalysisWidget() { stopEngine(); delete m_tablebase; }
+AnalysisWidget::~AnalysisWidget()
+{
+    stopEngine();
+    delete m_tablebase;
+}
 
 void AnalysisWidget::slotSpacebarPressed()
 {
-    if (isEngineRunning() && !m_analyses.isEmpty() && !m_analyses[0].variation().isEmpty())
-        emit addVariation(m_analyses[0].variation().at(0).toAlgebraic());
+    // Executes only if engine is running and has analysis lines available
+    if (isEngineRunning() && !m_analyses.isEmpty())
+    {
+        if (!m_analyses[0].variation().isEmpty())
+        {
+            emit addVariation(m_analyses[0].variation().at(0).toAlgebraic());
+        }
+    }
 }
 
-bool AnalysisWidget::hideLines() const { return m_hideLines; }
+bool AnalysisWidget::hideLines() const
+{
+    return m_hideLines;
+}
 
-void AnalysisWidget::setHideLines(bool newHideLines) { m_hideLines = newHideLines; updateAnalysis(); }
+void AnalysisWidget::setHideLines(bool newHideLines)
+{
+    m_hideLines = newHideLines;
+    updateAnalysis();
+}
 
 void AnalysisWidget::showContextMenu(const QPoint &pt)
 {
     QMenu* menu = ui.variationText->createStandardContextMenu(pt);
     QAction* action = new QAction(tr("Hide lines"));
+    action->setVisible(true);
     action->setCheckable(true);
     action->setChecked(m_hideLines);
     connect(action, SIGNAL(triggered(bool)),this,SLOT(setHideLines(bool)));
@@ -83,11 +106,16 @@ void AnalysisWidget::startEngine()
     m_onHold = false;
     if(index != -1)
     {
-        if(parentWidget() && !parentWidget()->isVisible()) parentWidget()->show();
+        if(parentWidget() && !parentWidget()->isVisible())
+        {
+            parentWidget()->show();
+        }
         ui.variationText->clear();
         m_engine = EngineX::newEngine(index);
         ui.vpcount->setEnabled(m_engine->providesMpv());
+        ui.label->setEnabled(m_engine->providesMpv());
         if(!m_engine->providesMpv()) ui.vpcount->setValue(1);
+
         connect(m_engine, SIGNAL(activated()), SLOT(engineActivated()));
         connect(m_engine, SIGNAL(error(QProcess::ProcessError)), SLOT(engineError(QProcess::ProcessError)));
         connect(m_engine, SIGNAL(deactivated()), SLOT(engineDeactivated()));
@@ -101,16 +129,31 @@ void AnalysisWidget::startEngine()
 void AnalysisWidget::stopEngine()
 {
     engineDeactivated();
-    if(m_engine) { m_engine->deactivate(); delete m_engine; m_engine.clear(); }
+    if(m_engine)
+    {
+        m_engine->deactivate();
+        delete m_engine;
+        m_engine.clear();
+    }
 }
 
 void AnalysisWidget::slotVisibilityChanged(bool visible)
 {
-    if(isEngineRunning() && !visible && !parentWidget()->isVisible()) stopEngine();
+    if(isEngineRunning() && !visible && !parentWidget()->isVisible())
+    {
+        stopEngine();
+    }
 }
 
-bool AnalysisWidget::isEngineRunning() const { return m_engine && ui.analyzeButton->isChecked(); }
-bool AnalysisWidget::isEngineConfigured() const { return (ui.engineList->currentIndex() != -1); }
+bool AnalysisWidget::isEngineRunning() const
+{
+    return m_engine && ui.analyzeButton->isChecked();
+}
+
+bool AnalysisWidget::isEngineConfigured() const
+{
+    return (ui.engineList->currentIndex() != -1);
+}
 
 void AnalysisWidget::engineActivated()
 {
@@ -128,24 +171,37 @@ void AnalysisWidget::engineActivated()
 
 void AnalysisWidget::engineError(QProcess::ProcessError e)
 {
-    MessageDialog::warning(tr("Error (%1) running engine <b>%2</b>.").arg(e).arg(ui.engineList->currentText()));
+    MessageDialog::warning(tr("There was an error (%1) running engine <b>%2</b>.")
+                           .arg(e).arg(ui.engineList->currentText()));
 }
 
-void AnalysisWidget::engineDeactivated() { ui.analyzeButton->setChecked(false); }
+void AnalysisWidget::engineDeactivated()
+{
+    ui.analyzeButton->setChecked(false);
+}
 
 void AnalysisWidget::slotSelectEngine()
 {
     EngineX* ex = EngineX::newEngine(ui.engineList->currentIndex());
-    if (ex) { int empv = ex->m_mapOptionValues.value("MultiPV",1).toInt(); if(empv>1) ui.vpcount->setValue(empv); delete ex; }
+    if (ex)
+    {
+        int empv = ex->m_mapOptionValues.value("MultiPV",1).toInt();
+        if(empv>1) ui.vpcount->setValue(empv);
+        delete ex;
+    }
     toggleAnalysis();
 }
 
-void AnalysisWidget::toggleAnalysis() { if(!isAnalysisEnabled()) stopEngine(); else startEngine(); }
+void AnalysisWidget::toggleAnalysis()
+{
+    if(!isAnalysisEnabled()) stopEngine();
+    else startEngine();
+}
 
-void AnalysisWidget::bookActivated(int)
+void AnalysisWidget::bookActivated(int index)
 {
     m_pBookDatabase.clear();
-    emit signalSourceChanged(ui.bookList->currentIndex()>=0 ? ui.bookList->itemData(ui.bookList->currentIndex()).toString() : "");
+    emit signalSourceChanged(index>=0 ? ui.bookList->itemData(index).toString() : "");
     updateBookMoves();
     updateAnalysis();
 }
@@ -159,21 +215,40 @@ void AnalysisWidget::slotPinChanged(bool pinned)
 void AnalysisWidget::slotReconfigure()
 {
     QString oldEngineName = ui.engineList->currentText();
-    if(oldEngineName.isEmpty()) oldEngineName = AppSettings->getValue(QString("/") + objectName() + "/Engine").toString();
-    EngineList enginesList; enginesList.restore();
+    if(oldEngineName.isEmpty())
+        oldEngineName = AppSettings->getValue(QString("/") + objectName() + "/Engine").toString();
+
+    EngineList enginesList;
+    enginesList.restore();
     QStringList names = enginesList.names();
-    ui.engineList->clear(); ui.engineList->insertItems(0, names);
+    ui.engineList->clear();
+    ui.engineList->insertItems(0, names);
     int index = names.indexOf(oldEngineName);
     ui.engineList->setCurrentIndex(index != -1 ? index : 0);
     if(index == -1) stopEngine();
+
     int mpv = AppSettings->value(QString("/") + objectName() + "/mpv", 1).toInt();
+    EngineX* ex = EngineX::newEngine(ui.engineList->currentIndex());
+    if (ex)
+    {
+        int empv = ex->m_mapOptionValues.value("MultiPV",1).toInt();
+        if (empv > 1) mpv = empv;
+        delete ex;
+    }
     ui.vpcount->setValue(mpv);
+
     int fontSize = std::max(AppSettings->getValue("/General/ListFontSize").toInt(), 8);
-    QFont f = ui.variationText->font(); f.setPointSize(fontSize);
+    QFont f = ui.variationText->font();
+    f.setPointSize(fontSize);
     ui.variationText->setFont(f);
 }
 
-void AnalysisWidget::saveConfig() { AppSettings->beginGroup(objectName()); AppSettings->setValue("LastBook", ui.bookList->currentText()); AppSettings->endGroup(); }
+void AnalysisWidget::saveConfig()
+{
+    AppSettings->beginGroup(objectName());
+    AppSettings->setValue("LastBook", ui.bookList->currentText());
+    AppSettings->endGroup();
+}
 
 void AnalysisWidget::restoreBook()
 {
@@ -187,95 +262,264 @@ void AnalysisWidget::restoreBook()
 void AnalysisWidget::slotUpdateBooks(QStringList files)
 {
     QString current = ui.bookList->currentText();
-    ui.bookList->clear(); ui.bookList->addItem("-",QVariant(QString()));
-    foreach(QString filename, files) { if (DatabaseInfo::IsBook(filename)) ui.bookList->addItem(QFileInfo(filename).baseName(), QVariant(filename)); }
-    int index = ui.bookList->findText(current); ui.bookList->setCurrentIndex(index < 0 ? 0 : index);
+    ui.bookList->clear();
+    ui.bookList->addItem("-",QVariant(QString()));
+    foreach(QString filename, files)
+    {
+        if (DatabaseInfo::IsBook(filename))
+            ui.bookList->addItem(QFileInfo(filename).baseName(), QVariant(filename));
+    }
+    int index = ui.bookList->findText(current);
+    ui.bookList->setCurrentIndex(index < 0 ? 0 : index);
 }
 
-void AnalysisWidget::setGameMode(bool gameMode) { m_gameMode = gameMode; if (!m_gameMode) updateBookMoves(); }
+void AnalysisWidget::setGameMode(bool gameMode)
+{
+    m_gameMode = gameMode;
+    if (!m_gameMode) updateBookMoves();
+}
 
 void AnalysisWidget::showAnalysis(Analysis analysis)
 {
     int elapsed = m_lastEngineStart.elapsed();
     int mpv = analysis.mpv() - 1;
-    if (analysis.bestMove()) { if (m_analyses.count() && m_analyses.last().bestMove()) m_analyses.removeLast(); m_analyses.append(analysis); }
-    else if(mpv < 0 || mpv >= ui.vpcount->value()) return;
+    bool bestMove = analysis.bestMove();
+    
+    if (bestMove)
+    {
+        if (m_analyses.count() && m_analyses.last().bestMove()) m_analyses.removeLast();
+        m_analyses.append(analysis);
+    }
+    else if(mpv < 0 || mpv > m_analyses.count() || mpv >= ui.vpcount->value()) return;
     else if(mpv == m_analyses.count()) m_analyses.append(analysis);
     else m_analyses[mpv] = analysis;
-    updateComplexity(); updateAnalysis();
-    if (analysis.bestMove()) { analysis.setElapsedTimeMS(elapsed); emit receivedBestMove(analysis); }
+
+    updateComplexity();
+    updateAnalysis();
+    
+    Analysis c = analysis;
+    if (bestMove && analysis.variation().count()) 
+    {
+        foreach (Analysis a, m_analyses)
+        {
+            if (a.variation().count() && a.variation().at(0)==analysis.variation().at(0))
+            {
+                c = a;
+                c.setBestMove(true);
+                break;
+            }
+        }
+    }
+
+    if (bestMove)
+    {
+        c.setElapsedTimeMS(elapsed);
+        emit receivedBestMove(c);
+    }
+    if (m_tb.isNullMove()) emit currentBestMove(c); 
 }
 
 void AnalysisWidget::setPosition(const BoardX& board, QString line)
 {
-    if (ui.btPin->isChecked()) { m_NextBoard = board; m_NextLine = line; return; }
+    if (ui.btPin->isChecked())
+    {
+        m_NextBoard = board;
+        m_NextLine = line;
+        return;
+    }
     if(m_board != board)
     {
-        m_board = board; m_line = line; m_analyses.clear();
-        m_tablebase->abortLookup(); m_tablebaseEvaluation.clear();
+        m_board = board;
+        m_NextBoard = board;
+        m_NextLine = line;
+        m_line = line;
+        m_analyses.clear();
+        m_tablebase->abortLookup();
+        m_tablebaseEvaluation.clear();
+        m_tablebaseMove.clear();
+        m_tb.setNullMove();
+        m_score_tb = 0;
+
         updateBookMoves();
-        if(AppSettings->getValue("/General/onlineTablebases").toBool() && !m_board.chess960()) m_tablebase->getBestMove(m_board.toFen());
+
+        if(AppSettings->getValue("/General/onlineTablebases").toBool())
+        {
+            if (!(m_board.isStalemate() || m_board.isCheckmate() || m_board.chess960()))
+            {
+                if(objectName() == "Analysis")
+                {
+                    m_tbBoard = m_board;
+                    m_tablebase->getBestMove(m_board.toFen());
+                }
+            }
+        }
+
+        m_lastDepthAdded = 0;
         updateAnalysis();
         if (m_engine && m_engine->isActive() && !onHold() && !sendBookMove())
         {
             if (m_bUciNewGame) m_engine->setStartPos(m_startPos);
             m_engine->startAnalysis(m_board, ui.vpcount->value(), m_moveTime, m_bUciNewGame, line);
-            m_lastEngineStart.start(); m_bUciNewGame = false;
+            m_lastEngineStart.start();
+            m_bUciNewGame = false;
         }
     }
 }
 
-bool AnalysisWidget::sendBookMove() { if (moveList.count() && m_moveTime.allowBook) { QTimer::singleShot(500, this, SLOT(sendBookMoveTimeout())); return true; } return false; }
+bool AnalysisWidget::sendBookMove()
+{
+    if (moveList.count() && m_moveTime.allowBook)
+    {
+        QTimer::singleShot(500, this, SLOT(sendBookMoveTimeout()));
+        return true;
+    }
+    return false;
+}
 
 void AnalysisWidget::sendBookMoveTimeout()
 {
     if (moveList.count() && m_moveTime.allowBook)
     {
-        Analysis analysis; Move::List moves;
-        moves.append(moveList.at(0).move);
-        analysis.setVariation(moves); analysis.setBestMove(true); analysis.setBookMove(true);
+        Analysis analysis;
+        Move::List moves;
+        int index = 0;
+        if (m_moveTime.bookMove == 1) index = QRandomGenerator::global()->bounded(0,moveList.count()-1);
+        else if (m_moveTime.bookMove == 2)
+        {
+            int randomPos = QRandomGenerator::global()->bounded(0,games-1);
+            for (int i=0; i<moveList.count();++i)
+            {
+                randomPos -= moveList.at(i).results.count();
+                if (randomPos<0) { index = i; break; }
+            }
+        }
+        moves.append(moveList.at(index).move);
+        analysis.setVariation(moves);
+        analysis.setBestMove(true);
+        analysis.setBookMove(true);
         emit receivedBestMove(analysis);
     }
 }
 
 void AnalysisWidget::slotLinkClicked(const QUrl& url)
 {
+    if (m_NextBoard != m_board) return; 
     QString linkData = url.toString();
-    if (linkData.startsWith("first:")) {
-        int idx = linkData.mid(6).toInt();
-        if(idx >= 0 && idx < m_analyses.count() && !m_analyses[idx].variation().isEmpty())
-            emit addVariation(m_analyses[idx].variation().at(0).toAlgebraic());
-    } else if (linkData.contains(',')) {
-        QStringList p = linkData.split(',');
-        int lIdx = p[0].toInt(), mIdx = p[1].toInt();
-        if (lIdx >= 0 && lIdx < m_analyses.count()) {
-            Analysis a = m_analyses[lIdx]; Move::List m;
-            for (int i=0; i<=mIdx && i<a.variation().count(); ++i) m.append(a.variation()[i]);
-            a.setVariation(m); emit addVariation(a, "");
+
+    if (linkData.startsWith("all:")) 
+    {
+        int lineIdx = linkData.mid(4).toInt();
+        if(lineIdx >= 0 && lineIdx < m_analyses.count()) emit addVariation(m_analyses[lineIdx], "");
+    }
+    else if (linkData.startsWith("first:")) 
+    {
+        int lineIdx = linkData.mid(6).toInt();
+        if(lineIdx >= 0 && lineIdx < m_analyses.count() && !m_analyses[lineIdx].variation().isEmpty())
+            emit addVariation(m_analyses[lineIdx].variation().at(0).toAlgebraic());
+    }
+    else if (linkData.contains(',')) 
+    {
+        QStringList parts = linkData.split(',');
+        int lineIdx = parts[0].toInt();
+        int moveIdx = parts[1].toInt();
+        if (lineIdx >= 0 && lineIdx < m_analyses.count()) 
+        {
+            Analysis a = m_analyses[lineIdx];
+            Move::List truncatedMoves;
+            for (int i = 0; i <= moveIdx && i < a.variation().count(); ++i) truncatedMoves.append(a.variation()[i]);
+            a.setVariation(truncatedMoves);
+            emit addVariation(a, "");
         }
     }
 }
 
-void AnalysisWidget::setMoveTime(EngineParameter mt) { m_moveTime = mt; if(isEngineRunning() && !ui.btPin->isChecked()) m_engine->setMoveTime(mt); }
-void AnalysisWidget::setMoveTime(int n) { EngineParameter p(n); p.analysisMode = true; setMoveTime(p); }
-void AnalysisWidget::setDepth(int n) { m_moveTime.searchDepth = n; m_moveTime.analysisMode = true; setMoveTime(m_moveTime); }
+void AnalysisWidget::setMoveTime(EngineParameter mt)
+{
+    m_moveTime = mt;
+    if(isEngineRunning() && !ui.btPin->isChecked()) m_engine->setMoveTime(mt);
+}
+
+void AnalysisWidget::setMoveTime(int n)
+{
+    EngineParameter par(n);
+    par.analysisMode = true;
+    setMoveTime(par);
+}
+
+void AnalysisWidget::setDepth(int n)
+{
+    m_moveTime.searchDepth = n;
+    m_moveTime.analysisMode = true;
+    setMoveTime(m_moveTime);
+}
 
 void AnalysisWidget::slotMpvChanged(int mpv)
 {
-    if(isEngineRunning()) { while(m_analyses.count() > mpv) m_analyses.removeLast(); m_engine->setMpv(mpv); }
+    if(isEngineRunning())
+    {
+        while(m_analyses.count() > mpv) m_analyses.removeLast();
+        m_engine->setMpv(mpv);
+    }
     AppSettings->setValue(QString("/") + objectName() + "/mpv", mpv);
 }
 
-bool AnalysisWidget::isAnalysisEnabled() const { return (parentWidget() && parentWidget()->isVisible() && ui.analyzeButton->isChecked()); }
+bool AnalysisWidget::isAnalysisEnabled() const
+{
+    return (parentWidget() && parentWidget()->isVisible() && ui.analyzeButton->isChecked());
+}
 
 void AnalysisWidget::showTablebaseMove(QList<Move> bestMoves, int score)
 {
-    if (!bestMoves.isEmpty())
+    if (m_tbBoard == m_board)
     {
-        Move m = m_board.prepareMove(bestMoves[0].from(), bestMoves[0].to());
-        if(bestMoves[0].isPromotion()) m.setPromoted(pieceType(bestMoves[0].promotedPiece()));
-        m_tablebaseEvaluation = QString("%1 (Score: %2)").arg(m_board.moveToFullSan(m,true)).arg(score);
+        bool first = true;
+        QStringList also;
+        if (!bestMoves.isEmpty()) foreach(Move move, bestMoves)
+        {
+            if (first)
+            {
+                first = false;
+                QString result;
+                bool dtm = false;
+                if (score > 0x800) { score -= 0x800; dtm = true; }
+                else if (score < -0x800) { score += 0x800; dtm = true; }
+                m_score_tb = 0;
+                if(score == 0) result = tr("Draw");
+                else
+                {
+                    if (dtm)
+                    {
+                        bool whiteMates = (score < 0) == (m_board.toMove() == Black);
+                        result = tr(whiteMates ? "White mates in %n move(s)" : "Black mates in %n move(s)", "", (qAbs(score)+1)/2);
+                        m_score_tb = whiteMates ? 1 : -1;
+                    }
+                    else
+                    {
+                        bool whiteWins = (score < 0) == (m_board.toMove() == Black);
+                        result = tr(whiteWins ? "White wins (reset in %n move(s))" : "Black wins (reset in %n move(s))", "", (qAbs(score)+1)/2);
+                        m_score_tb = whiteWins ? 1 : -1;
+                    }
+                }
+                Move move1 = m_board.prepareMove(move.from(), move.to());
+                if(move.isPromotion()) move1.setPromoted(pieceType(move.promotedPiece()));
+                m_tablebaseEvaluation = m_hideLines ? result : QString("%1 - %2").arg(m_board.moveToFullSan(move1,true), result);
+                m_tablebaseMove = m_board.moveToFullSan(move1);
+                m_tb = move1;
+                m_lastDepthAdded = 0;
+            }
+            else if (!m_hideLines)
+            {
+                Move move1 = m_board.prepareMove(move.from(), move.to());
+                if(move.isPromotion()) move1.setPromoted(pieceType(move.promotedPiece()));
+                also.append(m_board.moveToFullSan(move1,true));
+            }
+        }
+        if (!also.isEmpty()) m_tablebaseEvaluation.append(QString(" === %1").arg(also.join(" ")));
         updateAnalysis();
+        Analysis tbAnalysis;
+        tbAnalysis.setTb(m_tb);
+        tbAnalysis.setScoreTb(m_score_tb);
+        emit currentBestMove(tbAnalysis);
     }
 }
 
@@ -284,26 +528,58 @@ void AnalysisWidget::clear() { ui.variationText->clear(); }
 void AnalysisWidget::updateAnalysis()
 {
     QString text;
+    if (ui.btPin->isChecked()) text = tr("Analysis pinned to move %1").arg(m_board.moveNumber()) + "<br>";
+
     int lineIdx = 0;
-    foreach(Analysis a, m_analyses) {
-        Move::List moves = a.variation();
-        if (!moves.isEmpty()) {
-            QString score = (a.score() > 0 ? "+" : "") + QString::number(a.score()/100.0, 'f', 2);
-            QString s = QString("<a href=\"first:%1\">[+]</a> <b>%2</b> (%3) ").arg(lineIdx).arg(score).arg(a.depth());
-            BoardX temp = m_board;
-            for(int i=0; i<moves.count(); ++i) {
-                s += QString("<a href=\"%1,%2\">%3</a> ").arg(lineIdx).arg(i).arg(temp.moveToSan(moves[i]));
-                temp.doMove(moves[i]);
+    foreach(Analysis a, m_analyses)
+    {
+        if (m_hideLines) text.append(a.toString(m_board, true) + "<br>");
+        else 
+        {
+            Move::List moves = a.variation();
+            if (!moves.isEmpty()) 
+            {
+                double scoreVal = a.score() / 100.0;
+                QString scoreStr = (a.score() > 0 ? "+" : "") + QString::number(scoreVal, 'f', 2);
+                if (a.isMate()) scoreStr = "#" + QString::number(a.score());
+
+                QString s = QString("<a href=\"first:%1\" title=\"%2\">[+]</a> ").arg(lineIdx).arg(tr("Add first move"));
+                s += QString("<a href=\"all:%1\" style=\"text-decoration:none; color:black;\"><b>%2</b> (%3)</a> ")
+                     .arg(lineIdx).arg(scoreStr).arg(a.depth());
+                
+                BoardX tempBoard = m_board;
+                for(int i = 0; i < moves.count(); ++i) 
+                {
+                    QString rawMove = tempBoard.moveToSan(moves[i]); 
+                    QString fmt = (tempBoard.toMove() == White) ? QString("%1. %2").arg(tempBoard.moveNumber()).arg(rawMove) : (i==0 ? QString("%1... %2").arg(tempBoard.moveNumber()).arg(rawMove) : rawMove);
+                    s += QString("<a href=\"%1,%2\">%3</a> ").arg(lineIdx).arg(i).arg(fmt);
+                    tempBoard.doMove(moves[i]);
+                }
+                text.append(s + "<br>");
             }
-            text.append(s + "<br>");
         }
         lineIdx++;
     }
-    if(!m_tablebaseEvaluation.isEmpty()) text.append("<b>TB:</b> " + m_tablebaseEvaluation);
+
+    if(!m_tablebaseEvaluation.isEmpty())
+        text.append(QString("<a href=\"0\" title=\"%1\">[+]</a> <b>%2:</b> ").arg(tr("Click to add"), tr("Tablebase")) + m_tablebaseEvaluation);
+    
     ui.variationText->setText(text);
 }
 
-void AnalysisWidget::updateComplexity() {}
+void AnalysisWidget::updateComplexity()
+{
+    if (m_analyses.isEmpty() || m_analyses[0].variation().isEmpty()) { m_lastDepthAdded = 0; return; }
+    Move bestMove = m_analyses[0].variation().first();
+    if (m_analyses[0].depth() == 2) { m_lastBestMove = bestMove; m_complexity = 0.0; m_lastDepthAdded = 2; }
+    if (m_analyses.size() >= 2 && !m_analyses[1].bestMove() && m_lastDepthAdded+1 == m_analyses[0].depth() && !m_analyses[0].isMate())
+    {
+        m_lastDepthAdded = m_analyses[0].depth();
+        if (m_lastBestMove != bestMove && abs(m_analyses[0].score()) < 200)
+            m_complexity += fabs(double(m_analyses[0].score()-m_analyses[1].score()))/100.0;
+    }
+}
+
 Analysis AnalysisWidget::getMainLine() const { return m_analyses.isEmpty() ? Analysis() : m_analyses.first(); }
 bool AnalysisWidget::hasMainLine() const { return !m_analyses.isEmpty(); }
 QString AnalysisWidget::displayName() const { return ui.engineList->currentText(); }

--- a/src/gui/analysiswidget.cpp
+++ b/src/gui/analysiswidget.cpp
@@ -494,28 +494,50 @@ void AnalysisWidget::sendBookMoveTimeout()
 
 void AnalysisWidget::slotLinkClicked(const QUrl& url)
 {
-    if (m_NextBoard != m_board)
-    {
-        return; // Pinned and user moved somewhere else
+    if (m_NextBoard != m_board) 
+    { 
+        return; 
     }
-    int mpv = url.toString().toInt() - 1;
-    if(mpv >= 0 && mpv < m_analyses.count())
+
+    QString linkData = url.toString();
+
+    if (linkData.startsWith("all:")) 
     {
-        emit addVariation(m_analyses[mpv], "");
-    }
-    else if(mpv == -1)
-    {
-        emit addVariation(m_tablebaseMove);
-    }
-    else
-    {
-        mpv = (-mpv) - 2;
-        if(mpv < m_analyses.count())
+        int lineIdx = linkData.mid(4).toInt();
+        if(lineIdx >= 0 && lineIdx < m_analyses.count())
         {
-            if (!m_analyses[mpv].variation().isEmpty())
+            emit addVariation(m_analyses[lineIdx], "");
+        }
+    }
+    else if (linkData.startsWith("first:")) 
+    {
+        int lineIdx = linkData.mid(6).toInt();
+        if(lineIdx >= 0 && lineIdx < m_analyses.count())
+        {
+            if (!m_analyses[lineIdx].variation().isEmpty())
             {
-                emit addVariation(m_analyses[mpv].variation().at(0).toAlgebraic());
+                emit addVariation(m_analyses[lineIdx].variation().at(0).toAlgebraic());
             }
+        }
+    }
+    else if (linkData.contains(',')) 
+    {
+        QStringList parts = linkData.split(',');
+        int lineIdx = parts[0].toInt();
+        int moveIdx = parts[1].toInt();
+
+        if (lineIdx >= 0 && lineIdx < m_analyses.count()) 
+        {
+            Analysis a = m_analyses[lineIdx];
+            Move::List moves = a.variation();
+            Move::List truncatedMoves;
+            for (int i = 0; i <= moveIdx && i < moves.count(); ++i) 
+            {
+                truncatedMoves.append(moves[i]);
+            }
+            Analysis truncatedAnalysis = a;
+            truncatedAnalysis.setVariation(truncatedMoves);
+            emit addVariation(truncatedAnalysis, "");
         }
     }
 }
@@ -702,15 +724,62 @@ void AnalysisWidget::updateAnalysis()
         unsigned int moveNr = m_board.moveNumber();
         text = tr("Analysis pinned to move %1").arg(moveNr) + "<br>";
     }
+
+    int lineIdx = 0;
     foreach(Analysis a, m_analyses)
     {
-        QString s = a.toString(m_board, m_hideLines);
-        if (!s.isEmpty()) text.append(s + "<br>");
+        if (m_hideLines) 
+        {
+            QString s = a.toString(m_board, m_hideLines);
+            if (!s.isEmpty()) text.append(s + "<br>");
+        }
+        else 
+        {
+            QString s;
+            Move::List moves = a.variation();
+            if (!moves.isEmpty()) 
+            {
+                double scoreVal = a.score() / 100.0;
+                QString scoreStr = (a.score() > 0 ? "+" : "") + QString::number(scoreVal, 'f', 2);
+                if (a.isMate()) scoreStr = "#" + QString::number(a.score());
+
+                s += QString("<a href=\"first:%1\" title=\"%2\">[+]</a> ").arg(lineIdx).arg(tr("Add first move"));
+                s += QString("<b>%1</b> <a href=\"all:%2\">*</a> ").arg(scoreStr).arg(lineIdx);
+                
+                BoardX tempBoard = m_board;
+                for(int i = 0; i < moves.count(); ++i) 
+                {
+                    QString rawMove = tempBoard.moveToSan(moves[i]); 
+
+                    QString formattedMove;
+                    if (tempBoard.toMove() == White) 
+                    {
+                        formattedMove = QString("%1. %2").arg(tempBoard.moveNumber()).arg(rawMove);
+                    } 
+                    else if (i == 0) 
+                    {
+                        formattedMove = QString("%1... %2").arg(tempBoard.moveNumber()).arg(rawMove);
+                    } 
+                    else 
+                    {
+                        formattedMove = rawMove; 
+                    }
+
+                    s += QString("<a href=\"%1,%2\">%3</a> ").arg(lineIdx).arg(i).arg(formattedMove);
+                    
+                    tempBoard.doMove(moves[i]);
+                }
+                text.append(s + "<br>");
+            }
+        }
+        lineIdx++;
     }
+
     if(!m_tablebaseEvaluation.isEmpty())
     {
         text.append(QString("<a href=\"0\" title=\"%1\">[+]</a> <b>%2:</b> ").arg(tr("Click to add move to game"), tr("Tablebase")) + m_tablebaseEvaluation);
     }
+    
     if (m_lastDepthAdded == 17)
     {
         text.append(QString("<br><b>%1:</b> %2/%3<br>").arg(tr("Complexity")).arg(m_complexity).arg(m_complexity2));

--- a/src/gui/analysiswidget.h
+++ b/src/gui/analysiswidget.h
@@ -1,10 +1,10 @@
 /***************************************************************************
- *   (C) 2008-2010 Michal Rudolf <mrudolf@kdewebdev.org>                   *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
+ * (C) 2008-2010 Michal Rudolf <mrudolf@kdewebdev.org>                   *
+ * *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
  ***************************************************************************/
 
 #ifndef ANALYSIS_WIDGET_H_INCLUDED
@@ -18,6 +18,10 @@
 #include <QObject>
 #include <QPointer>
 #include <QShortcut>
+
+/** @ingroup GUI
+    The Analysis widget which shows engine output
+*/
 
 class Tablebase;
 class Database;
@@ -69,6 +73,8 @@ private slots:
     void slotPinChanged(bool);
     bool hideLines() const;
     void setHideLines(bool newHideLines);
+    
+    /** Handle the Spacebar shortcut */
     void slotSpacebarPressed();
 
 signals:
@@ -123,5 +129,4 @@ private:
     bool m_hideLines;
 };
 
-#endif
-
+#endif // ANALYSIS_WIDGET_H_INCLUDED

--- a/src/gui/analysiswidget.h
+++ b/src/gui/analysiswidget.h
@@ -17,10 +17,7 @@
 #include <QElapsedTimer>
 #include <QObject>
 #include <QPointer>
-
-/** @ingroup GUI
-	The Analysis widget which shows engine output
-*/
+#include <QShortcut>
 
 class Tablebase;
 class Database;
@@ -32,77 +29,47 @@ public:
     AnalysisWidget(QWidget* parent);
     ~AnalysisWidget();
 
-    /** Get the main line */
     Analysis getMainLine() const;
-    /** Analysis has a main line */
     bool hasMainLine() const;
-    /** Get the name of this widget */
     QString displayName() const;
-    /** Unpin the analyis (if pinned) */
     void unPin();
-    /** Is any engine running. */
     bool isEngineRunning() const;
-    /** Is any engine configured. */
     bool isEngineConfigured() const;
-
     bool onHold() const;
     void setOnHold(bool onHold);
-
     QString engineName() const;
     void updateBookFile(Database*);
-
     void clear();
 
 public slots:
-    /** Sets new position. If analysis is active, the current content will be cleared and
-    new analysis will be performed. */
     void setPosition(const BoardX& board, QString line="");
-    /** Called when configuration was changed (either on startup or from Preferences dialog. */
     void slotReconfigure();
-    /** Store current configuration. */
     void saveConfig();
-    /** Start currently selected engine. */
     void startEngine();
-    /** Stop any running  engine. */
     void stopEngine();
-    /** Stop game analysis when analysis dock is hidden. */
     void slotVisibilityChanged(bool);
-    /** Change the movetime of the engine */
     void setMoveTime(EngineParameter mt);
-    /** Change the movetime of the engine */
     void setMoveTime(int);
-    /** Change the search depth of the engine */
     void setDepth(int n);
-    /** Must send ucinewgame next time */
     void slotUciNewGame(const BoardX& b);
-    /** Called when the list of databases changes */
     void slotUpdateBooks(QStringList);
-    /** Called upon entering or leaving game mode */
     void setGameMode(bool);
-    /** Restore Book settings */
     void restoreBook();
+
 private slots:
-    /** Stop if analysis is no longer visible. */
     void toggleAnalysis();
     void slotSelectEngine();
-    /** Displays given analysis received from an engine. */
     void showAnalysis(Analysis analysis);
-    /** The engine is now ready, as requested */
     void engineActivated();
-    /** The engine is now deactivated */
     void engineDeactivated();
-    /** There was an error while running engine. */
     void engineError(QProcess::ProcessError);
-    /** Add variation. */
     void slotLinkClicked(const QUrl& link);
-    /** Number of visible lines was changed. */
     void slotMpvChanged(int mpv);
-    /** Show tablebase move information. */
     void showTablebaseMove(QList<Move> move, int score);
-    /** The pin button was pressed or released */
     void slotPinChanged(bool);
     bool hideLines() const;
     void setHideLines(bool newHideLines);
+    void slotSpacebarPressed();
 
 signals:
     void addVariation(const Analysis& analysis, const QString&);
@@ -115,14 +82,11 @@ signals:
 protected slots:
     void bookActivated(int);
     void sendBookMoveTimeout();
-
     void showContextMenu(const QPoint &pt);
+
 private:
-    /** Should analysis be running. */
     bool isAnalysisEnabled() const;
-    /** Update analysis. */
     void updateAnalysis();
-    /** Update complexity. */
     void updateComplexity();
     void updateBookMoves();
     bool sendBookMove();
@@ -157,7 +121,7 @@ private:
 
     bool m_gameMode;
     bool m_hideLines;
- };
+};
 
-#endif // ANALYSIS_WIDGET_H_INCLUDED
+#endif
 


### PR DESCRIPTION
This change allows users to click individual moves within an engine's analysis variation. Clicking a move will add the variation to the game up to that specific move, rather than adding the entire line. Standard functionality for the [+] and [*] buttons remains unchanged. UPD! Chessbase-like feature SPACEBAR for pasting best engine's move into the notation implemented as well